### PR TITLE
[ADD/#38] ScrapBox 컴포넌트 구현

### DIFF
--- a/core/src/main/java/com/terning/core/designsystem/component/box/ScrapBox.kt
+++ b/core/src/main/java/com/terning/core/designsystem/component/box/ScrapBox.kt
@@ -76,28 +76,28 @@ fun ScrapBox(
     }
 }
 
-@Preview(showBackground = true, showSystemUi = true)
+@Preview(showBackground = true)
 @Composable
-fun ScrapBoxPreview() {
-    Column {
-        ScrapBox(
-            modifier = Modifier
-                .height(116.dp)
-                .width(140.dp),
-            scrapColor = CalPink,
-            cornerRadius = 5.dp,
-            borderWidth = 1.dp
-        ) {}
+fun BorderedScrapBoxPreview() {
+    ScrapBox(
+        modifier = Modifier
+            .height(116.dp)
+            .width(140.dp),
+        scrapColor = CalPink,
+        cornerRadius = 5.dp,
+        borderWidth = 1.dp
+    ) {}
+}
 
-        Spacer(modifier = Modifier.height(10.dp))
-
-        ScrapBox(
-            modifier = Modifier
-                .height(height = 92.dp)
-                .fillMaxWidth(),
-            scrapColor = CalPurple,
-            cornerRadius = 10.dp,
-            elevation = 1.dp
-        ) {}
-    }
+@Preview(showBackground = true)
+@Composable
+fun ShadowedScrapBoxPreview() {
+    ScrapBox(
+        modifier = Modifier
+            .height(height = 92.dp)
+            .fillMaxWidth(),
+        scrapColor = CalPurple,
+        cornerRadius = 10.dp,
+        elevation = 1.dp
+    ) {}
 }

--- a/core/src/main/java/com/terning/core/designsystem/component/box/ScrapBox.kt
+++ b/core/src/main/java/com/terning/core/designsystem/component/box/ScrapBox.kt
@@ -1,0 +1,95 @@
+package com.terning.core.designsystem.component.box
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.terning.core.designsystem.theme.CalPink
+import com.terning.core.designsystem.theme.CalPurple
+import com.terning.core.designsystem.theme.Grey150
+import com.terning.core.designsystem.theme.White
+
+@Composable
+fun ScrapBox(
+    cornerRadius: Dp,
+    scrapColor: Color,
+    modifier: Modifier = Modifier,
+    elevation: Dp = 0.dp,
+    borderWidth: Dp = 0.dp,
+    borderColor: Color = Grey150,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .border(
+                width = borderWidth,
+                color = borderColor,
+                RoundedCornerShape(cornerRadius),
+            )
+            .shadow(
+                elevation = elevation,
+                RoundedCornerShape(cornerRadius),
+            )
+    ) {
+        Box(
+            modifier = Modifier
+                .background(
+                    color = scrapColor,
+                    shape = RoundedCornerShape(cornerRadius)
+                )
+                .fillMaxSize()
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = 9.dp)
+                .background(
+                    shape = RoundedCornerShape(
+                        topEnd = cornerRadius, bottomEnd = cornerRadius
+                    ), color = White
+                )
+        ) {
+            content()
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun ScrapBoxPreview() {
+    Column {
+        ScrapBox(
+            modifier = Modifier
+                .height(116.dp)
+                .width(140.dp),
+            scrapColor = CalPink,
+            cornerRadius = 5.dp,
+            borderWidth = 1.dp
+        ) {}
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        ScrapBox(
+            modifier = Modifier
+                .height(height = 92.dp)
+                .fillMaxWidth(),
+            scrapColor = CalPurple,
+            cornerRadius = 10.dp,
+            elevation = 1.dp
+        ) {}
+    }
+}

--- a/core/src/main/java/com/terning/core/designsystem/component/box/ScrapBox.kt
+++ b/core/src/main/java/com/terning/core/designsystem/component/box/ScrapBox.kt
@@ -23,6 +23,14 @@ import com.terning.core.designsystem.theme.CalPurple
 import com.terning.core.designsystem.theme.Grey150
 import com.terning.core.designsystem.theme.White
 
+/**
+ * ScrapBox is made for easy customization of scrap box used in Calendar & Home Screen
+ *
+ * [modifier] must be assigned for assigning size of the box and padding
+ * [elevation] must be set greater than zero for shadow effect, mainly used in Calendar
+ * [borderWidth] must be set greater than zero for border effect, mainly used in Home
+ */
+
 @Composable
 fun ScrapBox(
     cornerRadius: Dp,


### PR DESCRIPTION
- closed #38 

## *⛳️ Work Description*
- 홈화면과 캘린더 스크랩 화면에서 공통적으로 사용되는 박스 컴포넌트 구현

## *📸 Screenshot*
<img width="330" alt="image" src="https://github.com/teamterning/Terning-Android/assets/101652649/8602f1fb-dc8a-4061-8982-cc4778e45306">

## *📢 To Reviewers*
홈 화면과 캘린더 화면에서 사용되는 스크랩 박스 컴포넌트입니다.
- `modifier`를 통해 박스의 크기를 지정 합니다.
- `content`로 박스 우측에 들어갈 컴포저블을 지정합니다.
- `borderWidth`와 `elevation`을 사용하여 박스의 테두리와 그림자 효과를 부여합니다.

홈화면에서 사용되는지 캘린더 화면에서 사용되는지를 구분하지 않았기 때문에, 사용하실 때 직접 modifier를 통해 뷰의 크기 지정을 해줘야 합니다!!