### PR TITLE
[FIX/#296] DateTimeException 해결

### DIFF
--- a/feature/src/main/java/com/terning/feature/calendar/calendar/CalendarRoute.kt
+++ b/feature/src/main/java/com/terning/feature/calendar/calendar/CalendarRoute.kt
@@ -91,7 +91,12 @@ private fun CalendarScreen(
         snapshotFlow { pagerState.currentPage }
             .collect { current ->
                 val date = getLocalDateByPage(current)
-                val newDate = LocalDate.of(date.year, date.month, uiState.selectedDate.dayOfMonth)
+
+                val newDate = LocalDate.of(
+                    date.year,
+                    date.month,
+                    uiState.selectedDate.dayOfMonth.coerceAtMost(date.month.minLength())
+                )
                 updateSelectedDate(newDate)
             }
     }


### PR DESCRIPTION
- closed #296 

## *⛳️ Work Description*
- `coerceAtMost`로 달력 전환 시 선택된 날짜이 현재 달의 최대 날짜보다 큰 경우, 현재 달의 최대 날짜로 조절하도록 수정
- 현재 달의 최대 날짜는 `LocalDate.month.minLength`로 불러옴

## *📸 Screenshot*
- 문제 상황
   
   https://github.com/user-attachments/assets/840db89a-b995-4811-9cd3-5bd9eee6812a

- 문제 해결

   https://github.com/user-attachments/assets/ca88647b-fa8b-43c7-918b-2cd315a76f9a

## *📢 To Reviewers*
- PlayConsole 구경하다가 에러 터졌다고 해서 급하게 수정했어요,,,
- 후딱 머지하고 31일 되기 전에 업데이트합시당ㅋㅎㅋ
