### PR TITLE
[FIX/#319] 필터링 재설정 뷰 / 데이트피커 로직 수정 

### DIFF
--- a/feature/home/src/main/java/com/terning/feature/home/component/HomeYearMonthPicker.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/HomeYearMonthPicker.kt
@@ -1,6 +1,5 @@
 package com.terning.feature.home.component
 
-import android.util.Log
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -76,11 +75,9 @@ fun HomeYearMonthPicker(
     val startYearIndex =
         if (isYearNull) yearsList.lastIndex else yearsList.indexOf("${chosenYear ?: "-"}년")
             .takeIf { it >= 0 } ?: yearsList.lastIndex
-    Log.d("LYB", "INSIDE datapicker startYearIndex = $startYearIndex")
     val startMonthIndex =
         if (isMonthNull) monthsList.lastIndex else monthsList.indexOf("${chosenMonth ?: "-"}월")
             .takeIf { it >= 0 } ?: monthsList.lastIndex
-    Log.d("LYB", "INSIDE datapicker startMonthIndex = $startMonthIndex")
 
     Row(
         modifier = modifier
@@ -95,7 +92,6 @@ fun HomeYearMonthPicker(
             startIndex = startYearIndex,
             onItemSelected = { year ->
                 if (year == NULL_DATE && !isInitialSelection) isInitialSelection = true
-                Log.d("LYB", "INSIDE datepicker year = $year")
                 onYearChosen(
                     if (year == NULL_DATE) null else year.dropLast(1).toInt(),
                     isInitialSelection
@@ -139,7 +135,7 @@ fun DatePicker(
         if (itemHeightPixel > 0 && startIndex >= 0) scrollState.scrollToItem(startIndex)
     }
 
-    var savedIndex by remember { mutableIntStateOf(startIndex) }
+    val savedIndex by remember { mutableIntStateOf(startIndex) }
 
     LaunchedEffect(itemHeightPixel, savedIndex) {
         scrollState.scrollToItem(savedIndex)
@@ -151,14 +147,12 @@ fun DatePicker(
                 val hasNullDate =
                     items.size == (END_YEAR - START_YEAR + 1) || items.size == (END_MONTH - START_MONTH + 1)
                 val adjustedItems = if (hasNullDate) items + NULL_DATE else items
-                Log.d("LYB", "***index*** = $index")
                 adjustedItems.getOrNull(index)
             }
             .distinctUntilChanged()
             .collect { item ->
                 item?.let {
                     pickerState.selectedItem = it
-                    Log.d("LYB", "INSIDE datepicker it = $it")
                     onItemSelected(it)
                 }
             }

--- a/feature/home/src/main/java/com/terning/feature/home/component/HomeYearMonthPicker.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/HomeYearMonthPicker.kt
@@ -75,13 +75,12 @@ fun HomeYearMonthPicker(
 
     val startYearIndex =
         if (isYearNull) yearsList.lastIndex else yearsList.indexOf("${chosenYear ?: "-"}년")
-            .takeIf { it >= 0 } ?: 0
+            .takeIf { it >= 0 } ?: yearsList.lastIndex
     Log.d("LYB", "INSIDE datapicker startYearIndex = $startYearIndex")
     val startMonthIndex =
         if (isMonthNull) monthsList.lastIndex else monthsList.indexOf("${chosenMonth ?: "-"}월")
-            .takeIf { it >= 0 } ?: 0
+            .takeIf { it >= 0 } ?: monthsList.lastIndex
     Log.d("LYB", "INSIDE datapicker startMonthIndex = $startMonthIndex")
-
 
     Row(
         modifier = modifier
@@ -139,27 +138,20 @@ fun DatePicker(
     LaunchedEffect(itemHeightPixel, startIndex) {
         if (itemHeightPixel > 0 && startIndex >= 0) scrollState.scrollToItem(startIndex)
     }
-    // 현재 index를 상태로 저장
+
     var savedIndex by remember { mutableIntStateOf(startIndex) }
 
     LaunchedEffect(itemHeightPixel, savedIndex) {
-//        if (itemHeightPixel > 0 && savedIndex > 0) {
         scrollState.scrollToItem(savedIndex)
     }
-    // }
 
     LaunchedEffect(scrollState) {
         snapshotFlow { scrollState.firstVisibleItemIndex }
             .map { index ->
-//                savedIndex = index // 현재 index를 저장
                 val hasNullDate =
                     items.size == (END_YEAR - START_YEAR + 1) || items.size == (END_MONTH - START_MONTH + 1)
                 val adjustedItems = if (hasNullDate) items + NULL_DATE else items
                 Log.d("LYB", "***index*** = $index")
-
-                if (index == 12) savedIndex = 12
-                if (index == 21) savedIndex = 21
-                Log.d("LYB", "***savedIndex*** = $savedIndex")
                 adjustedItems.getOrNull(index)
             }
             .distinctUntilChanged()

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
@@ -125,24 +125,23 @@ fun PlanFilteringScreen(
             modifier = Modifier
                 .padding(24.dp)
         )
-        Log.d("LYB", "current startYear = ${currentFilteringInfo.startYear}")
-        Log.d("LYB", "current startMonth = ${currentFilteringInfo.startMonth}")
+
         HomeYearMonthPicker(
             chosenYear = currentFilteringInfo.startYear,
             chosenMonth = currentFilteringInfo.startMonth,
             onYearChosen = { year, isInitialSelection ->
+                Log.d("LYB", "current year = ${year}")
+                updateStartYear(year)
                 if (year != null) {
-                    Log.d("LYB", "current year = ${year}")
-                    updateStartYear(year)
                     isCheckBoxChecked = false
                     isYearNull = false
                     isInitialNullState = isInitialSelection
                 }
             },
             onMonthChosen = { month, isInitialSelection ->
+                Log.d("LYB", "current month = ${month}")
+                updateStartMonth(month)
                 if (month != null) {
-                    Log.d("LYB", "current month = ${month}")
-                    updateStartMonth(month)
                     isCheckBoxChecked = false
                     isMonthNull = false
                     isInitialNullState = isInitialSelection

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
@@ -1,5 +1,6 @@
 package com.terning.feature.home.component.bottomsheet
 
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -50,8 +51,8 @@ fun PlanFilteringScreen(
     updateStartYear: (Int?) -> Unit,
     updateStartMonth: (Int?) -> Unit,
 ) {
-    var isYearNull by remember { mutableStateOf(currentFilteringInfo.startYear == null) }
-    var isMonthNull by remember { mutableStateOf(currentFilteringInfo.startMonth == null) }
+    var isYearNull by remember { mutableStateOf(currentFilteringInfo.startYear == 0) }
+    var isMonthNull by remember { mutableStateOf(currentFilteringInfo.startMonth == 0) }
 
     var isCheckBoxChecked by remember { mutableStateOf(false) }
 
@@ -124,12 +125,14 @@ fun PlanFilteringScreen(
             modifier = Modifier
                 .padding(24.dp)
         )
-
+        Log.d("LYB", "current startYear = ${currentFilteringInfo.startYear}")
+        Log.d("LYB", "current startMonth = ${currentFilteringInfo.startMonth}")
         HomeYearMonthPicker(
             chosenYear = currentFilteringInfo.startYear,
             chosenMonth = currentFilteringInfo.startMonth,
             onYearChosen = { year, isInitialSelection ->
                 if (year != null) {
+                    Log.d("LYB", "current year = ${year}")
                     updateStartYear(year)
                     isCheckBoxChecked = false
                     isYearNull = false
@@ -138,6 +141,7 @@ fun PlanFilteringScreen(
             },
             onMonthChosen = { month, isInitialSelection ->
                 if (month != null) {
+                    Log.d("LYB", "current month = ${month}")
                     updateStartMonth(month)
                     isCheckBoxChecked = false
                     isMonthNull = false

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
@@ -51,8 +51,8 @@ fun PlanFilteringScreen(
     updateStartYear: (Int?) -> Unit,
     updateStartMonth: (Int?) -> Unit,
 ) {
-    var isYearNull by remember { mutableStateOf(currentFilteringInfo.startYear == 0) }
-    var isMonthNull by remember { mutableStateOf(currentFilteringInfo.startMonth == 0) }
+    var isYearNull by remember { mutableStateOf(currentFilteringInfo.startYear == 0 || currentFilteringInfo.startYear == null) }
+    var isMonthNull by remember { mutableStateOf(currentFilteringInfo.startMonth == 0 || currentFilteringInfo.startMonth == null) }
 
     var isCheckBoxChecked by remember { mutableStateOf(false) }
 


### PR DESCRIPTION
- closed #319

## *⛳️ Work Description*
#### 데이트 피커 수정된 사항
- 처음 체크박스 선택 시에도 저장버튼은 활성화 됨
- 저장한 값 그대로 뜸
- 년, 월 중 하나라도 null일 경우 저장 버튼은 비활성화됨
#### 기타 수정사항
- [x] startYear와 startMonth가 0일때와 null인 경우 모두 확인하도록 반영
- [x] 체크박스 조건 부 `||` 추가

## *📸 Screenshot*

https://github.com/user-attachments/assets/f146d7b7-2044-4416-b9e8-0fe2598f6c39



## *📢 To Reviewers*
- 사실 코드가 크게 바뀐 건 없구 기존 오류 사항들은 많이 잡혔어요
- 효빈언니 브렌치로 머지하도록 되어있어서 꼭 제 피알 머지하구 313번 브렌치 머지해주세용...!!!!!!
- 추가로 체크박스 활성여부 작성하는 줄에 `||`가 빠져있어서 이것만 추가했어요..! 혹시 이 부분 효빈언니 브렌치에 이미 반영되있다면 지우도록 할게요!