### PR TITLE
[FIX/#324] 바텀바, 달력 / 3차 스프린트 QA 반영

### DIFF
--- a/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/CalendarRoute.kt
+++ b/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/CalendarRoute.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier

--- a/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/CalendarRoute.kt
+++ b/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/CalendarRoute.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -47,6 +49,7 @@ fun CalendarRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val amplitudeTracker = LocalTracker.current
 
+
     CalendarScreen(
         uiState = uiState,
         navigateToAnnouncement = navigateToAnnouncement,
@@ -65,6 +68,12 @@ fun CalendarRoute(
         },
         modifier = modifier,
     )
+
+    DisposableEffect(true) {
+        onDispose {
+            viewModel.resetUiState()
+        }
+    }
 }
 
 @Composable
@@ -89,6 +98,10 @@ private fun CalendarScreen(
         initialPage = uiState.calendarModel.initialPage,
         pageCount = { uiState.calendarModel.pageCount }
     )
+
+    LaunchedEffect(true) {
+        pagerState.scrollToPage(uiState.calendarModel.initialPage)
+    }
 
     LaunchedEffect(key1 = pagerState, key2 = uiState.selectedDate) {
         snapshotFlow { pagerState.currentPage }
@@ -115,7 +128,7 @@ private fun CalendarScreen(
             date = uiState.calendarModel.getYearMonthByPage(pagerState.settledPage),
             isListExpanded = uiState.isListEnabled,
             onListButtonClicked = {
-                if(!calendarListTransition.isRunning)
+                if (!calendarListTransition.isRunning)
                     onClickListButton()
             },
             onMonthNavigationButtonClicked = { direction ->

--- a/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/CalendarViewModel.kt
+++ b/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/CalendarViewModel.kt
@@ -27,6 +27,14 @@ class CalendarViewModel @Inject constructor() : ViewModel() {
         }
     }
 
+    fun resetUiState() = _uiState.update { currentState ->
+        currentState.copy(
+            selectedDate = DayModel(),
+            isListEnabled = false,
+            isWeekEnabled = false
+        )
+    }
+
     fun updateSelectedDate(value: DayModel) = _uiState.update { currentState ->
             currentState.copy(
                 selectedDate = value

--- a/feature/main/src/main/java/com/terning/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/terning/feature/main/MainScreen.kt
@@ -3,20 +3,11 @@ package com.terning.feature.main
 import android.app.Activity
 import android.content.Intent
 import androidx.activity.compose.BackHandler
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideIn
-import androidx.compose.animation.slideOut
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
@@ -30,20 +21,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navOptions
 import com.terning.core.analytics.EventType
 import com.terning.core.designsystem.component.snackbar.TerningBasicSnackBar
-import com.terning.core.designsystem.theme.Grey300
-import com.terning.core.designsystem.theme.TerningMain
 import com.terning.core.designsystem.theme.White
-import com.terning.core.designsystem.util.NoRippleInteractionSource
 import com.terning.feature.calendar.calendar.navigation.calendarNavGraph
 import com.terning.feature.calendar.calendar.navigation.navigateCalendar
 import com.terning.feature.filtering.filteringone.navigation.filteringOneNavGraph
@@ -57,6 +41,7 @@ import com.terning.feature.home.navigation.homeNavGraph
 import com.terning.feature.home.navigation.navigateHome
 import com.terning.feature.intern.navigation.internNavGraph
 import com.terning.feature.intern.navigation.navigateIntern
+import com.terning.feature.main.component.MainBottomBar
 import com.terning.feature.mypage.mypage.navigation.myPageNavGraph
 import com.terning.feature.mypage.profileedit.navigation.profileEditNavGraph
 import com.terning.feature.onboarding.signin.navigation.navigateSignIn
@@ -68,7 +53,6 @@ import com.terning.feature.onboarding.splash.navigation.splashNavGraph
 import com.terning.feature.search.search.navigation.searchNavGraph
 import com.terning.feature.search.searchprocess.navigation.navigateSearchProcess
 import com.terning.feature.search.searchprocess.navigation.searchProcessNavGraph
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 
@@ -273,52 +257,6 @@ fun MainScreen(
                     }
                 )
                 profileEditNavGraph(navHostController = navigator.navController)
-            }
-        }
-    }
-}
-
-@Composable
-private fun MainBottomBar(
-    isVisible: Boolean,
-    tabs: ImmutableList<MainTab>,
-    currentTab: MainTab?,
-    onTabSelected: (MainTab) -> Unit,
-) {
-    AnimatedVisibility(
-        visible = isVisible,
-        enter = fadeIn() + slideIn { IntOffset(0, 0) },
-        exit = fadeOut() + slideOut { IntOffset(0, 0) }
-    ) {
-        NavigationBar(containerColor = White) {
-            tabs.forEach { itemType ->
-                NavigationBarItem(
-                    interactionSource = NoRippleInteractionSource,
-                    selected = currentTab == itemType,
-                    onClick = {
-                        onTabSelected(itemType)
-                    },
-                    icon = {
-                        Icon(
-                            painter = painterResource(id = (itemType.icon)),
-                            contentDescription = stringResource(id = itemType.contentDescription)
-                        )
-                    },
-                    label = {
-                        Text(
-                            stringResource(id = itemType.contentDescription),
-                            fontSize = 9.sp
-                        )
-                    },
-                    colors = NavigationBarItemDefaults
-                        .colors(
-                            selectedIconColor = TerningMain,
-                            selectedTextColor = TerningMain,
-                            unselectedIconColor = Grey300,
-                            unselectedTextColor = Grey300,
-                            indicatorColor = White
-                        )
-                )
             }
         }
     }

--- a/feature/main/src/main/java/com/terning/feature/main/component/MainBottomBar.kt
+++ b/feature/main/src/main/java/com/terning/feature/main/component/MainBottomBar.kt
@@ -1,0 +1,98 @@
+package com.terning.feature.main.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideIn
+import androidx.compose.animation.slideOut
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.terning.core.designsystem.extension.customShadow
+import com.terning.core.designsystem.theme.Grey300
+import com.terning.core.designsystem.theme.TerningMain
+import com.terning.core.designsystem.theme.TerningPointTheme
+import com.terning.core.designsystem.theme.White
+import com.terning.core.designsystem.util.NoRippleInteractionSource
+import com.terning.feature.main.MainTab
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+@Composable
+internal fun MainBottomBar(
+    isVisible: Boolean,
+    tabs: ImmutableList<MainTab>,
+    currentTab: MainTab?,
+    onTabSelected: (MainTab) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = isVisible,
+        enter = fadeIn() + slideIn { IntOffset(0, 0) },
+        exit = fadeOut() + slideOut { IntOffset(0, 0) }
+    ) {
+        NavigationBar(
+            containerColor = White,
+            modifier = modifier.customShadow(
+                shadowWidth = 2.dp,
+            ),
+        ) {
+            tabs.forEach { itemType ->
+                NavigationBarItem(
+                    interactionSource = NoRippleInteractionSource,
+                    selected = currentTab == itemType,
+                    onClick = { onTabSelected(itemType) },
+                    icon = {
+                        Icon(
+                            painter = painterResource(id = (itemType.icon)),
+                            contentDescription = stringResource(id = itemType.contentDescription)
+                        )
+                    },
+                    label = {
+                        Text(
+                            stringResource(id = itemType.contentDescription),
+                            fontSize = 9.sp
+                        )
+                    },
+                    colors = NavigationBarItemDefaults
+                        .colors(
+                            selectedIconColor = TerningMain,
+                            selectedTextColor = TerningMain,
+                            unselectedIconColor = Grey300,
+                            unselectedTextColor = Grey300,
+                            indicatorColor = White
+                        )
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MainBottomBarPreview() {
+    TerningPointTheme {
+        Column {
+            Spacer(Modifier.height(20.dp))
+            MainBottomBar(
+                isVisible = true,
+                tabs = MainTab.entries.toImmutableList(),
+                currentTab = MainTab.HOME,
+                onTabSelected = {}
+            )
+        }
+    }
+}

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -6,6 +6,6 @@
     <string name="bottom_nav_home">홈</string>
     <string name="bottom_nav_calendar">캘린더</string>
     <string name="bottom_nav_search">탐색</string>
-    <string name="bottom_nav_my_page">마이페이지</string>
+    <string name="bottom_nav_my_page">마이</string>
 
 </resources>


### PR DESCRIPTION
- closed #324 

## *⛳️ Work Description*
- 달력 화면 진입시 상태 초기화
- 바텀바 마이페이지 라이팅 수정
- 미사용 라이브러리 삭제

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

| 바텀바 수정 | 달력상태 관리 |
|:----------:|:------------:|
| <img src="https://github.com/user-attachments/assets/8a0aa8b1-389f-4eac-836d-9b3e3851db5f" width=270 /> | <video src="https://github.com/user-attachments/assets/40b59dfb-900c-491d-81ac-2b34aca83046" width=270 /> |

## *📢 To Reviewers*
- 바텀바를 수정하면서 패키지 위치도 옮겨버렸습니다! 이유는 프리뷰와 주석 작성인데, MainScreen 안에 있으니까 두 개를 작성하는게 지저분하더라구요,,
- 그림자를 `1.dp`를 적용했을 땐 그냥 줄 하나 그어놓은 것 같아서 `2.dp`로 설정했습니다!
- 홈화면 상태 관리도 알아보려고 했는데, Paging이 통신마다 새로운 flow를 받아오는 구조라 페이지 위치를 보존하기엔 어려울 것 같아서 일단 안건드렸습니다!
