### PR TITLE
[FIX/#323] 홈, 필터링 재설정 뷰 / 1차 QA 반영

### DIFF
--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -28,8 +28,8 @@
 
     <!--SortByBottom-->
     <string name="sort_by_earliest">채용 마감 이른 순</string>
-    <string name="sort_by_shortest">짧은 근무 기간 순</string>
-    <string name="sort_by_longest">긴 근무 기간 순</string>
+    <string name="sort_by_shortest">근무 기간 짧은 순</string>
+    <string name="sort_by_longest">근무 기간 긴 순</string>
     <string name="sort_by_scrap">스크랩 많은 순</string>
     <string name="sort_by_view_count">조회수 많은 순</string>
     <string name="sort_button_description">정렬 기준</string>

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/HomeFilteringBottomSheet.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/HomeFilteringBottomSheet.kt
@@ -68,6 +68,14 @@ internal fun HomeFilteringBottomSheet(
     val density = LocalDensity.current
     var pageHeight by remember { mutableIntStateOf(0) }
 
+    var isCheckBoxChecked by remember {
+        mutableStateOf(
+            with(currentFilteringInfo) {
+                listOf(grade, workingPeriod, startYear, startMonth).all { it == null || it == 0 }
+            }
+        )
+    }
+
     GetPagerHeight(
         onHeightMeasured = {
             pageHeight = it
@@ -137,6 +145,7 @@ internal fun HomeFilteringBottomSheet(
                         1 -> {
                             PlanFilteringScreen(
                                 currentFilteringInfo = currentFilteringInfo,
+                                isCheckBoxChecked = isCheckBoxChecked,
                                 updateGrade = {
                                     currentFilteringInfo = currentFilteringInfo.copy(
                                         grade = if (it != null) {
@@ -161,6 +170,9 @@ internal fun HomeFilteringBottomSheet(
                                         startMonth = it
                                     )
                                 },
+                                updateIsCheckBoxChecked = {
+                                    isCheckBoxChecked = it
+                                }
                             )
                         }
                     }
@@ -184,7 +196,10 @@ internal fun HomeFilteringBottomSheet(
                             )
                         }
                     },
-                    isEnabled = checkButtonEnable(currentFilteringInfo = currentFilteringInfo)
+                    isEnabled = checkButtonEnable(
+                        currentFilteringInfo = currentFilteringInfo,
+                        isCheckBoxChecked = isCheckBoxChecked
+                    )
                 )
             }
 
@@ -238,10 +253,12 @@ fun TerningTab(
     }
 }
 
-private fun checkButtonEnable(currentFilteringInfo: HomeFilteringInfo): Boolean =
+private fun checkButtonEnable(
+    currentFilteringInfo: HomeFilteringInfo,
+    isCheckBoxChecked: Boolean
+): Boolean =
     with(currentFilteringInfo) {
-        listOf(grade, workingPeriod, startYear, startMonth).all { it == null || it == 0 } ||
-                listOf(grade, workingPeriod, startYear, startMonth).none { it == null || it == 0 }
+        isCheckBoxChecked || listOf(grade, workingPeriod, startYear, startMonth).none { it == null }
     }
 
 @Composable
@@ -250,6 +267,7 @@ private fun GetPagerHeight(
 ) {
     PlanFilteringScreen(
         currentFilteringInfo = HomeFilteringInfo(null, null, null, null, "total"),
+        isCheckBoxChecked = false,
         modifier = Modifier
             .onGloballyPositioned {
                 onHeightMeasured(it.size.height)

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/HomeFilteringBottomSheet.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/HomeFilteringBottomSheet.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -68,10 +67,6 @@ internal fun HomeFilteringBottomSheet(
 
     val density = LocalDensity.current
     var pageHeight by remember { mutableIntStateOf(0) }
-
-    LaunchedEffect(pagerState.currentPage) {
-        currentFilteringInfo = defaultFilteringInfo
-    }
 
     GetPagerHeight(
         onHeightMeasured = {

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
@@ -52,7 +52,13 @@ internal fun PlanFilteringScreen(
     var isYearNull by remember { mutableStateOf(currentFilteringInfo.startYear == 0 || currentFilteringInfo.startYear == null) }
     var isMonthNull by remember { mutableStateOf(currentFilteringInfo.startMonth == 0 || currentFilteringInfo.startMonth == null) }
 
-    var isCheckBoxChecked by remember { mutableStateOf(false) }
+    var isCheckBoxChecked by remember {
+        mutableStateOf(
+            with(currentFilteringInfo) {
+                listOf(grade, workingPeriod, startYear, startMonth).all { it == null || it == 0 }
+            }
+        )
+    }
 
     var isInitialNullState by remember { mutableStateOf(false) }
 

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
@@ -43,22 +43,16 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 internal fun PlanFilteringScreen(
     currentFilteringInfo: HomeFilteringInfo,
+    isCheckBoxChecked: Boolean,
     modifier: Modifier = Modifier,
     updateGrade: (Int?) -> Unit = {},
     updateWorkingPeriod: (Int?) -> Unit = {},
     updateStartYear: (Int?) -> Unit = {},
     updateStartMonth: (Int?) -> Unit = {},
+    updateIsCheckBoxChecked: (Boolean) -> Unit = {},
 ) {
     var isYearNull by remember { mutableStateOf(currentFilteringInfo.startYear == 0 || currentFilteringInfo.startYear == null) }
     var isMonthNull by remember { mutableStateOf(currentFilteringInfo.startMonth == 0 || currentFilteringInfo.startMonth == null) }
-
-    var isCheckBoxChecked by remember {
-        mutableStateOf(
-            with(currentFilteringInfo) {
-                listOf(grade, workingPeriod, startYear, startMonth).all { it == null || it == 0 }
-            }
-        )
-    }
 
     var isInitialNullState by remember { mutableStateOf(false) }
 
@@ -99,7 +93,7 @@ internal fun PlanFilteringScreen(
             ).toImmutableList(),
             onButtonClick = {
                 updateGrade(it)
-                isCheckBoxChecked = false
+                updateIsCheckBoxChecked(false)
             },
             columns = 4,
             modifier = Modifier
@@ -124,7 +118,7 @@ internal fun PlanFilteringScreen(
             ).toImmutableList(),
             onButtonClick = {
                 updateWorkingPeriod(it)
-                isCheckBoxChecked = false
+                updateIsCheckBoxChecked(false)
             },
             modifier = Modifier
                 .padding(horizontal = 23.dp),
@@ -142,7 +136,7 @@ internal fun PlanFilteringScreen(
             onYearChosen = { year, isInitialSelection ->
                 updateStartYear(year)
                 if (year != null) {
-                    isCheckBoxChecked = false
+                    updateIsCheckBoxChecked(false)
                     isYearNull = false
                     isInitialNullState = isInitialSelection
                 }
@@ -150,7 +144,7 @@ internal fun PlanFilteringScreen(
             onMonthChosen = { month, isInitialSelection ->
                 updateStartMonth(month)
                 if (month != null) {
-                    isCheckBoxChecked = false
+                    updateIsCheckBoxChecked(false)
                     isMonthNull = false
                     isInitialNullState = isInitialSelection
                 }
@@ -185,7 +179,7 @@ internal fun PlanFilteringScreen(
                             updateStartYear(null)
                             updateStartMonth(null)
                         }
-                        isCheckBoxChecked = isChecked
+                        updateIsCheckBoxChecked(isChecked)
                     },
                     colors = CheckboxDefaults.colors(
                         checkedColor = TerningMain,


### PR DESCRIPTION
- closed #323

## *⛳️ Work Description*
- 홈, 검색 뷰 정렬 버튼 라이팅 수정
- 필터링 재설정 뷰 진입 시 계획 필터링 null일 경우 체크박스 체크
- 체크박스 해제 시 저장하기 버튼 비활성화
- 페이지 이동 시 선택한 필터링 정보 유지

## *📸 Screenshot*
https://github.com/user-attachments/assets/5af0bf0a-f292-4c99-9b5a-48e4ce5114ce


## *📢 To Reviewers*
- 짜잔~~ QA 다 반영했습니다!!
- 혹시 잘못 적용된 부분들 있으면 말씀해주세요..!!