### PR TITLE
[FIX/#322] 온보딩, 데이트피커 / 3차 스프린트 QA 반영

### DIFF
--- a/core/designsystem/src/main/java/com/terning/core/designsystem/util/CalendarDefaults.kt
+++ b/core/designsystem/src/main/java/com/terning/core/designsystem/util/CalendarDefaults.kt
@@ -1,8 +1,14 @@
 package com.terning.core.designsystem.util
 
+import com.terning.core.designsystem.extension.currentMonth
+import com.terning.core.designsystem.extension.currentYear
+import java.util.Calendar
+
 object CalendarDefaults {
     const val START_YEAR = 2010
-    const val END_YEAR = 2030
+    val END_YEAR =
+        if (Calendar.getInstance().currentMonth == 10) Calendar.getInstance().currentYear + 1
+        else Calendar.getInstance().currentYear
     const val START_MONTH = 1
     const val END_MONTH = 12
 }

--- a/core/designsystem/src/main/java/com/terning/core/designsystem/util/CalendarDefaults.kt
+++ b/core/designsystem/src/main/java/com/terning/core/designsystem/util/CalendarDefaults.kt
@@ -7,7 +7,7 @@ import java.util.Calendar
 object CalendarDefaults {
     const val START_YEAR = 2010
     val END_YEAR =
-        if (Calendar.getInstance().currentMonth == 10) Calendar.getInstance().currentYear + 1
+        if (Calendar.getInstance().currentMonth >= 10) Calendar.getInstance().currentYear + 1
         else Calendar.getInstance().currentYear
     const val START_MONTH = 1
     const val END_MONTH = 12

--- a/feature/filtering/src/main/java/com/terning/feature/filtering/startfiltering/StartFilteringRoute.kt
+++ b/feature/filtering/src/main/java/com/terning/feature/filtering/startfiltering/StartFilteringRoute.kt
@@ -106,7 +106,7 @@ fun StartFilteringScreen(
             onStartClick = onStartClick,
             onLaterClick = onLaterClick
         )
-        Spacer(modifier = Modifier.height((24 * screenHeight).dp))
+        Spacer(modifier = Modifier.height((16 * screenHeight).dp))
     }
 }
 
@@ -133,7 +133,7 @@ private fun ButtonAnimation(
                 cornerRadius = 10.dp,
                 modifier = Modifier.padding(horizontal = 24.dp)
             )
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(20.dp))
             Text(
                 text = stringResource(R.string.start_filtering_later),
                 style = TerningTheme.typography.detail3.copy(

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/HomeYearMonthPicker.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/HomeYearMonthPicker.kt
@@ -130,12 +130,6 @@ private fun DatePicker(
         if (itemHeightPixel > 0 && startIndex >= 0) scrollState.scrollToItem(startIndex)
     }
 
-    val savedIndex by remember { mutableIntStateOf(startIndex) }
-
-    LaunchedEffect(itemHeightPixel, savedIndex) {
-        scrollState.scrollToItem(savedIndex)
-    }
-
     LaunchedEffect(scrollState) {
         snapshotFlow { scrollState.firstVisibleItemIndex }
             .map { index ->

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/HomeYearMonthPicker.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/HomeYearMonthPicker.kt
@@ -58,19 +58,16 @@ private fun rememberPickerState() = remember { PickerState() }
 internal fun HomeYearMonthPicker(
     chosenYear: Int?,
     chosenMonth: Int?,
-    onYearChosen: (Int?, Boolean) -> Unit,
-    onMonthChosen: (Int?, Boolean) -> Unit,
+    onYearChosen: (Int?) -> Unit,
+    onMonthChosen: (Int?) -> Unit,
     isYearNull: Boolean,
     isMonthNull: Boolean,
     yearsList: ImmutableList<String>,
     monthsList: ImmutableList<String>,
-    isInitialNullState: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val yearPickerState = rememberPickerState()
     val monthPickerState = rememberPickerState()
-
-    var isInitialSelection by remember { mutableStateOf(isInitialNullState) }
 
     val startYearIndex =
         if (isYearNull) yearsList.lastIndex else yearsList.indexOf("${chosenYear ?: "-"}년")
@@ -91,10 +88,9 @@ internal fun HomeYearMonthPicker(
             items = yearsList,
             startIndex = startYearIndex,
             onItemSelected = { year ->
-                if (year == NULL_DATE && !isInitialSelection) isInitialSelection = true
                 onYearChosen(
-                    if (year == NULL_DATE) null else year.dropLast(1).toInt(),
-                    isInitialSelection
+                    if (year == NULL_DATE) null
+                    else year.dropLast(1).toInt()
                 )
             }
         )
@@ -105,10 +101,9 @@ internal fun HomeYearMonthPicker(
             items = monthsList,
             startIndex = startMonthIndex,
             onItemSelected = { month ->
-                if (month == NULL_DATE && !isInitialSelection) isInitialSelection = true
                 onMonthChosen(
-                    if (month == NULL_DATE) null else month.dropLast(1).toInt(),
-                    isInitialSelection
+                    if (month == NULL_DATE) null
+                    else month.dropLast(1).toInt()
                 )
             }
         )

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/HomeYearMonthPicker.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/HomeYearMonthPicker.kt
@@ -70,10 +70,10 @@ internal fun HomeYearMonthPicker(
     val monthPickerState = rememberPickerState()
 
     val startYearIndex =
-        if (isYearNull) yearsList.lastIndex else yearsList.indexOf("${chosenYear ?: "-"}년")
+        if (isYearNull) yearsList.lastIndex else yearsList.indexOf("${chosenYear ?: NULL_DATE}년")
             .takeIf { it >= 0 } ?: yearsList.lastIndex
     val startMonthIndex =
-        if (isMonthNull) monthsList.lastIndex else monthsList.indexOf("${chosenMonth ?: "-"}월")
+        if (isMonthNull) monthsList.lastIndex else monthsList.indexOf("${chosenMonth ?: NULL_DATE}월")
             .takeIf { it >= 0 } ?: monthsList.lastIndex
 
     Row(

--- a/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/component/bottomsheet/PlanFilteringScreen.kt
@@ -54,17 +54,15 @@ internal fun PlanFilteringScreen(
 
     var isCheckBoxChecked by remember { mutableStateOf(false) }
 
-    var isInitialNullState by remember { mutableStateOf(false) }
-
     val yearsList by remember(isYearNull) {
         mutableStateOf(
-            if (isYearNull || isInitialNullState) years + NULL_DATE
+            if (isYearNull) years + NULL_DATE
             else years
         )
     }
     val monthsList by remember(isMonthNull) {
         mutableStateOf(
-            if (isMonthNull || isInitialNullState) months + NULL_DATE
+            if (isMonthNull) months + NULL_DATE
             else months
         )
     }
@@ -133,27 +131,24 @@ internal fun PlanFilteringScreen(
         HomeYearMonthPicker(
             chosenYear = currentFilteringInfo.startYear,
             chosenMonth = currentFilteringInfo.startMonth,
-            onYearChosen = { year, isInitialSelection ->
+            onYearChosen = { year ->
                 updateStartYear(year)
                 if (year != null) {
                     isCheckBoxChecked = false
                     isYearNull = false
-                    isInitialNullState = isInitialSelection
                 }
             },
-            onMonthChosen = { month, isInitialSelection ->
+            onMonthChosen = { month ->
                 updateStartMonth(month)
                 if (month != null) {
                     isCheckBoxChecked = false
                     isMonthNull = false
-                    isInitialNullState = isInitialSelection
                 }
             },
             isYearNull = isYearNull,
             isMonthNull = isMonthNull,
             yearsList = yearsList.toImmutableList(),
             monthsList = monthsList.toImmutableList(),
-            isInitialNullState = isInitialNullState
         )
 
         Row(

--- a/feature/mypage/src/main/java/com/terning/feature/mypage/mypage/MyPageRoute.kt
+++ b/feature/mypage/src/main/java/com/terning/feature/mypage/mypage/MyPageRoute.kt
@@ -77,6 +77,7 @@ fun MyPageRoute(
         )
     }
 
+
     DisposableEffect(lifecycleOwner) {
         onDispose {
             systemUiController.setStatusBarColor(

--- a/feature/mypage/src/main/java/com/terning/feature/mypage/mypage/MyPageRoute.kt
+++ b/feature/mypage/src/main/java/com/terning/feature/mypage/mypage/MyPageRoute.kt
@@ -77,7 +77,6 @@ fun MyPageRoute(
         )
     }
 
-
     DisposableEffect(lifecycleOwner) {
         onDispose {
             systemUiController.setStatusBarColor(


### PR DESCRIPTION
- closed #322

## *⛳️ Work Description*
- [x] 온보딩 버튼 간의 간격 넓히기
- [x] 근무시작 시기 범위 줄이기 
- [x] 데이트피커 스크롤 시 '-' 없애기

## *📸 Screenshot*
| 온보딩 | 데이트피커 |
|:----------:|:------------:|
| <img src="https://github.com/user-attachments/assets/8bb9a949-3132-4f97-a1f7-cb92ed18bfa0" width=300 /> | <video src="https://github.com/user-attachments/assets/7e211fff-0845-4381-9966-a32f09909322" width=270 /> |


## *📢 To Reviewers*
- 3차 스프린트 1차 큐에이 완료!!
