### PR TITLE
[FIX/#330] 달력 영역 수정

### DIFF
--- a/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/component/group/CalendarWeekGroup.kt
+++ b/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/component/group/CalendarWeekGroup.kt
@@ -3,6 +3,7 @@ package com.terning.feature.calendar.calendar.component.group
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
@@ -45,7 +46,7 @@ internal fun CalendarWeekGroup(
     ){
         dayModels.forEach { dayModel ->
             Column(
-                modifier = Modifier
+                modifier = (Modifier.fillMaxHeight().takeIf { !isWeekEnabled } ?: Modifier)
                     .weight(1f)
                     .noRippleClickable {
                         if (!dayModel.isOutDate) {
@@ -107,7 +108,7 @@ private fun CalendarWeekGroupScrapPreview() {
 
         CalendarWeekGroup(
             selectedDay = DayModel(date = LocalDate.now().minusDays(1), weekIndex = 0, isOutDate = false),
-            isWeekEnabled = false,
+            isWeekEnabled = true,
             dayModels = listOf(
                 DayModel(date = LocalDate.now().minusDays(3), weekIndex = 0, isOutDate = false),
                 DayModel(date = LocalDate.now().minusDays(2), weekIndex = 0, isOutDate = false),


### PR DESCRIPTION
- closed #330 

## *⛳️ Work Description*
- 월간 달력 터치 영역 수정

## *📸 Screenshot*
https://github.com/user-attachments/assets/94c750a3-89fd-4a48-8229-b6db1edc4c8f

## *📢 To Reviewers*

- 2025년 1월 13일, 2024-25 잉글랜드 FA컵 3라운드 맨체스터 유나이티드 vs 아스널 경기를 시청하던 중 터닝 디자이너님께서 올려주신 QA를 빠르게 해결한 PR입니다.
- 맨체스터 유나이티드의 승리를 기원합니다.
