### PR TITLE
[FEAT/#382] FCM 푸시알림 커스텀 / Payload 형식에 맞게 구현

### DIFF
--- a/core/designsystem/src/main/java/com/terning/core/designsystem/type/NotificationRedirect.kt
+++ b/core/designsystem/src/main/java/com/terning/core/designsystem/type/NotificationRedirect.kt
@@ -1,0 +1,12 @@
+package com.terning.core.designsystem.type
+
+enum class NotificationRedirect(val path: String) {
+    CALENDAR("calendar"),
+    HOME("home"),
+    SEARCH("search");
+
+    companion object {
+        fun from(type: String?): NotificationRedirect? =
+            entries.firstOrNull { it.path.equals(type, ignoreCase = true) }
+    }
+}

--- a/core/designsystem/src/main/java/com/terning/core/designsystem/util/DeeplinkDefaults.kt
+++ b/core/designsystem/src/main/java/com/terning/core/designsystem/util/DeeplinkDefaults.kt
@@ -2,5 +2,6 @@ package com.terning.core.designsystem.util
 
 object DeeplinkDefaults {
     const val REDIRECT: String = "redirect"
+
     fun build(base: String) = "terning://${base}"
 }

--- a/core/designsystem/src/main/java/com/terning/core/designsystem/util/DeeplinkDefaults.kt
+++ b/core/designsystem/src/main/java/com/terning/core/designsystem/util/DeeplinkDefaults.kt
@@ -1,0 +1,6 @@
+package com.terning.core.designsystem.util
+
+object DeeplinkDefaults {
+    const val REDIRECT: String = "redirect"
+    fun build(base: String) = "terning://${base}"
+}

--- a/core/firebase/build.gradle.kts
+++ b/core/firebase/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 dependencies {
     //core
     implementation(projects.core.navigator)
+    implementation(projects.core.designsystem)
 
     // domain
     implementation(projects.domain.user)

--- a/core/firebase/build.gradle.kts
+++ b/core/firebase/build.gradle.kts
@@ -23,4 +23,7 @@ dependencies {
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.messaging)
     implementation(libs.firebase.config)
+
+    // coil
+    implementation(libs.coil.compose)
 }

--- a/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
+++ b/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
@@ -136,10 +136,11 @@ class TerningMessagingService : FirebaseMessagingService() {
     private fun isAppInForeground(): Boolean {
         val appProcesses =
             (getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager).runningAppProcesses
-        val packageName = packageName
         return appProcesses?.any {
-            it.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND &&
-                    it.processName == packageName
+            val isForeground =
+                it.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            val isCurrentApp = it.processName == packageName
+            isForeground && isCurrentApp
         } == true
     }
 

--- a/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
+++ b/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
@@ -136,10 +136,12 @@ class TerningMessagingService : FirebaseMessagingService() {
     private fun isAppInForeground(): Boolean {
         val appProcesses =
             (getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager).runningAppProcesses
+
         return appProcesses?.any {
             val isForeground =
                 it.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
             val isCurrentApp = it.processName == packageName
+
             isForeground && isCurrentApp
         } == true
     }

--- a/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
+++ b/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
@@ -43,11 +43,13 @@ class TerningMessagingService : FirebaseMessagingService() {
         val title = intent?.getStringExtra(TITLE).orEmpty()
         val body = intent?.getStringExtra(BODY).orEmpty()
         val type = intent?.getStringExtra(TYPE).orEmpty()
+        val imageUrl = intent?.getStringExtra(IMAGE_URL).orEmpty()
 
         sendNotification(
             title = title,
             body = body,
-            type = type
+            type = type,
+            imageUrl = imageUrl
         )
     }
 
@@ -61,15 +63,22 @@ class TerningMessagingService : FirebaseMessagingService() {
         val title = message.data[TITLE].orEmpty()
         val body = message.data[BODY].orEmpty()
         val type = message.data[TYPE].orEmpty()
+        val imageUrl = message.data[IMAGE_URL].orEmpty()
 
         sendNotification(
             title = title,
             body = body,
-            type = type
+            type = type,
+            imageUrl = imageUrl
         )
     }
 
-    private fun sendNotification(title: String, body: String, type: String) {
+    private fun sendNotification(
+        title: String,
+        body: String,
+        type: String,
+        imageUrl: String
+    ) {
         val notifyId = Random().nextInt()
         val intent = navigatorProvider.getMainActivityIntent(deeplink = type).apply {
             action = Intent.ACTION_VIEW
@@ -109,5 +118,6 @@ class TerningMessagingService : FirebaseMessagingService() {
         private const val TITLE: String = "title"
         private const val BODY: String = "body"
         private const val TYPE: String = "type"
+        private const val IMAGE_URL: String = "imageUrl"
     }
 }

--- a/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
+++ b/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
@@ -86,7 +86,7 @@ class TerningMessagingService : FirebaseMessagingService() {
     ) {
         val notifyId = Random().nextInt()
         val isForeground = isAppInForeground()
-        val deeplink = buildRedirect(type, isForeground)
+        val deeplink = buildDeeplink(type, isForeground)
         val intent = navigatorProvider.getMainActivityIntent(deeplink = deeplink).apply {
             action = Intent.ACTION_VIEW
             data = deeplink.toUri()
@@ -143,7 +143,7 @@ class TerningMessagingService : FirebaseMessagingService() {
         } == true
     }
 
-    private fun buildRedirect(type: String, isForeground: Boolean): String {
+    private fun buildDeeplink(type: String, isForeground: Boolean): String {
         val base = NotificationRedirect.from(type) ?: return ""
 
         return if (isForeground) DeeplinkDefaults.build(base.path)

--- a/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
+++ b/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
@@ -158,4 +158,3 @@ class TerningMessagingService : FirebaseMessagingService() {
         private const val IMAGE_URL: String = "imageUrl"
     }
 }
-

--- a/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/CalendarRoute.kt
+++ b/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/CalendarRoute.kt
@@ -23,13 +23,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.terning.core.analytics.EventType
 import com.terning.core.analytics.LocalTracker
 import com.terning.core.designsystem.component.topappbar.CalendarTopAppBar
 import com.terning.core.designsystem.extension.getWeekIndexContainingSelectedDate
 import com.terning.core.designsystem.theme.Grey200
-import com.terning.core.designsystem.theme.White
 import com.terning.feature.calendar.calendar.component.ScreenTransition
 import com.terning.feature.calendar.calendar.component.WeekDaysHeader
 import com.terning.feature.calendar.calendar.model.CalendarUiState
@@ -49,13 +47,6 @@ fun CalendarRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val amplitudeTracker = LocalTracker.current
-
-    val systemUiController = rememberSystemUiController()
-
-    LaunchedEffect(Unit) {
-        systemUiController.setStatusBarColor(color = White)
-        systemUiController.setNavigationBarColor(color = White)
-    }
 
     CalendarScreen(
         uiState = uiState,

--- a/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/CalendarRoute.kt
+++ b/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/CalendarRoute.kt
@@ -23,11 +23,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.terning.core.analytics.EventType
 import com.terning.core.analytics.LocalTracker
 import com.terning.core.designsystem.component.topappbar.CalendarTopAppBar
 import com.terning.core.designsystem.extension.getWeekIndexContainingSelectedDate
 import com.terning.core.designsystem.theme.Grey200
+import com.terning.core.designsystem.theme.White
 import com.terning.feature.calendar.calendar.component.ScreenTransition
 import com.terning.feature.calendar.calendar.component.WeekDaysHeader
 import com.terning.feature.calendar.calendar.model.CalendarUiState
@@ -48,6 +50,12 @@ fun CalendarRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val amplitudeTracker = LocalTracker.current
 
+    val systemUiController = rememberSystemUiController()
+
+    LaunchedEffect(Unit) {
+        systemUiController.setStatusBarColor(color = White)
+        systemUiController.setNavigationBarColor(color = White)
+    }
 
     CalendarScreen(
         uiState = uiState,

--- a/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/navigation/CalendarNavigation.kt
+++ b/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/navigation/CalendarNavigation.kt
@@ -7,10 +7,12 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import com.terning.core.navigation.MainTabRoute
 import com.terning.feature.calendar.calendar.CalendarRoute
 import kotlinx.serialization.Serializable
 
+private const val CALENDAR_PATH: String = "terning://calendar"
 
 fun NavController.navigateCalendar(navOptions: NavOptions? = null) {
     navigate(
@@ -23,7 +25,13 @@ fun NavGraphBuilder.calendarNavGraph(
     navigateIntern: (Long) -> Unit,
     paddingValues: PaddingValues
 ) {
-    composable<Calendar> {
+    composable<Calendar>(
+        deepLinks = listOf(
+            navDeepLink<Calendar>(
+                basePath = CALENDAR_PATH
+            )
+        )
+    ) {
         CalendarRoute(
             modifier = Modifier.padding(paddingValues),
             navigateToAnnouncement = navigateIntern

--- a/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/navigation/CalendarNavigation.kt
+++ b/feature/calendar/src/main/java/com/terning/feature/calendar/calendar/navigation/CalendarNavigation.kt
@@ -8,11 +8,10 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
+import com.terning.core.designsystem.util.DeeplinkDefaults
 import com.terning.core.navigation.MainTabRoute
 import com.terning.feature.calendar.calendar.CalendarRoute
 import kotlinx.serialization.Serializable
-
-private const val CALENDAR_PATH: String = "terning://calendar"
 
 fun NavController.navigateCalendar(navOptions: NavOptions? = null) {
     navigate(
@@ -28,7 +27,7 @@ fun NavGraphBuilder.calendarNavGraph(
     composable<Calendar>(
         deepLinks = listOf(
             navDeepLink<Calendar>(
-                basePath = CALENDAR_PATH
+                basePath = DeeplinkDefaults.build("calendar")
             )
         )
     ) {

--- a/feature/home/src/main/java/com/terning/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/HomeRoute.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -106,19 +105,11 @@ fun HomeRoute(
     }
 
     val systemUiController = rememberSystemUiController()
-    SideEffect {
-        systemUiController.setStatusBarColor(
-            color = White
-        )
-        systemUiController.setNavigationBarColor(
-            color = White
-        )
+
+    LaunchedEffect(Unit) {
+        systemUiController.setStatusBarColor(color = White)
+        systemUiController.setNavigationBarColor(color = White)
     }
-
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val context = LocalContext.current
-
-    val amplitudeTracker = LocalTracker.current
 
     LaunchedEffect(key1 = true) {
         viewModel.getProfile()
@@ -126,6 +117,9 @@ fun HomeRoute(
         viewModel.getHomeUpcomingInternList()
         viewModel.getRecommendInternFlow()
     }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
 
     LaunchedEffect(viewModel.homeSideEffect, lifecycleOwner) {
         viewModel.homeSideEffect.flowWithLifecycle(lifecycle = lifecycleOwner.lifecycle)
@@ -137,6 +131,8 @@ fun HomeRoute(
                 }
             }
     }
+
+    val amplitudeTracker = LocalTracker.current
 
     HomeScreen(
         paddingValues = paddingValues,

--- a/feature/home/src/main/java/com/terning/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/HomeRoute.kt
@@ -40,7 +40,6 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.terning.core.analytics.EventType
 import com.terning.core.analytics.LocalTracker
 import com.terning.core.designsystem.R.raw.paging_loading_animation
@@ -102,13 +101,6 @@ fun HomeRoute(
                     viewModel.updatePermissionRequested(true)
                 }
         }
-    }
-
-    val systemUiController = rememberSystemUiController()
-
-    LaunchedEffect(Unit) {
-        systemUiController.setStatusBarColor(color = White)
-        systemUiController.setNavigationBarColor(color = White)
     }
 
     LaunchedEffect(key1 = true) {

--- a/feature/home/src/main/java/com/terning/feature/home/navigation/HometNavigation.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/navigation/HometNavigation.kt
@@ -8,11 +8,10 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
+import com.terning.core.designsystem.util.DeeplinkDefaults
 import com.terning.core.navigation.MainTabRoute
 import com.terning.feature.home.HomeRoute
 import kotlinx.serialization.Serializable
-
-private const val HOME_PATH: String = "terning://home"
 
 fun NavController.navigateHome(navOptions: NavOptions? = null) {
     navigate(
@@ -30,7 +29,7 @@ fun NavGraphBuilder.homeNavGraph(
     composable<Home>(
         deepLinks = listOf(
             navDeepLink<Home>(
-                basePath = HOME_PATH
+                basePath = DeeplinkDefaults.build("home")
             )
         )
     ) {

--- a/feature/home/src/main/java/com/terning/feature/home/navigation/HometNavigation.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/navigation/HometNavigation.kt
@@ -1,13 +1,18 @@
 package com.terning.feature.home.navigation
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import com.terning.core.navigation.MainTabRoute
 import com.terning.feature.home.HomeRoute
 import kotlinx.serialization.Serializable
+
+private const val HOME_PATH: String = "terning://home"
 
 fun NavController.navigateHome(navOptions: NavOptions? = null) {
     navigate(
@@ -16,12 +21,19 @@ fun NavController.navigateHome(navOptions: NavOptions? = null) {
     )
 }
 
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
 fun NavGraphBuilder.homeNavGraph(
     paddingValues: PaddingValues,
     navigateToCalendar: () -> Unit,
     navigateToIntern: (Long) -> Unit
 ) {
-    composable<Home> {
+    composable<Home>(
+        deepLinks = listOf(
+            navDeepLink<Home>(
+                basePath = HOME_PATH
+            )
+        )
+    ) {
         HomeRoute(
             paddingValues = paddingValues,
             navigateToCalendar = navigateToCalendar,

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -11,6 +11,7 @@ android {
 dependencies {
     // core
     implementation(projects.core.navigator)
+    implementation(projects.core.firebase)
 
     // feature
     implementation(projects.feature.calendar)

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     // core
     implementation(projects.core.navigator)
     implementation(projects.core.firebase)
+    implementation(projects.core.designsystem)
 
     // feature
     implementation(projects.feature.calendar)

--- a/feature/main/src/main/java/com/terning/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/terning/feature/main/MainActivity.kt
@@ -28,10 +28,12 @@ class MainActivity : ComponentActivity() {
         setContent {
             val navigator: MainNavigator = rememberMainNavigator()
             val redirect: String? = intent.data?.getQueryParameter(REDIRECT)
+            val host: String? = intent.data?.host
 
             TerningPointTheme {
                 CompositionLocalProvider(LocalTracker provides tracker) {
                     MainScreen(
+                        host = host,
                         redirect = redirect,
                         navigator = navigator
                     )

--- a/feature/main/src/main/java/com/terning/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/terning/feature/main/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import com.terning.core.analytics.AmplitudeTracker
 import com.terning.core.analytics.LocalTracker
 import com.terning.core.designsystem.theme.TerningPointTheme
+import com.terning.core.designsystem.util.DeeplinkDefaults.REDIRECT
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -43,8 +44,6 @@ class MainActivity : ComponentActivity() {
     }
 
     companion object {
-        private const val REDIRECT: String = "redirect"
-
         fun getIntent(
             context: Context,
         ) = Intent(context, MainActivity::class.java)

--- a/feature/main/src/main/java/com/terning/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/terning/feature/main/MainNavigator.kt
@@ -8,9 +8,12 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
+import com.terning.feature.calendar.calendar.navigation.Calendar
 import com.terning.feature.calendar.calendar.navigation.navigateCalendar
+import com.terning.feature.home.navigation.Home
 import com.terning.feature.home.navigation.navigateHome
 import com.terning.feature.mypage.mypage.navigation.navigateMyPage
+import com.terning.feature.search.search.navigation.Search
 import com.terning.feature.search.search.navigation.navigateSearch
 import com.terning.feature.splash.navigation.Splash
 
@@ -22,7 +25,12 @@ class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    fun getStartDestination(redirect: String?) = Splash(redirect = redirect)
+    fun getStartDestination(redirect: String?, host: String?) = when (host) {
+        "search" -> Search
+        "home" -> Home
+        "calendar" -> Calendar
+        else -> Splash(redirect)
+    }
 
     val currentTab: MainTab?
         @Composable get() = MainTab.find { tab ->

--- a/feature/main/src/main/java/com/terning/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/terning/feature/main/MainNavigator.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
+import com.terning.core.designsystem.type.NotificationRedirect
 import com.terning.feature.calendar.calendar.navigation.Calendar
 import com.terning.feature.calendar.calendar.navigation.navigateCalendar
 import com.terning.feature.home.navigation.Home
@@ -25,12 +26,13 @@ class MainNavigator(
         @Composable get() = navController
             .currentBackStackEntryAsState().value?.destination
 
-    fun getStartDestination(redirect: String?, host: String?) = when (host) {
-        "search" -> Search
-        "home" -> Home
-        "calendar" -> Calendar
-        else -> Splash(redirect)
-    }
+    fun getStartDestination(redirect: String?, host: String?) =
+        when (NotificationRedirect.from(host)) {
+            NotificationRedirect.SEARCH -> Search
+            NotificationRedirect.HOME -> Home
+            NotificationRedirect.CALENDAR -> Calendar
+            else -> Splash(redirect)
+        }
 
     val currentTab: MainTab?
         @Composable get() = MainTab.find { tab ->

--- a/feature/main/src/main/java/com/terning/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/terning/feature/main/MainScreen.kt
@@ -51,6 +51,7 @@ import com.terning.feature.onboarding.signin.navigation.navigateSignIn
 import com.terning.feature.onboarding.signin.navigation.signInNavGraph
 import com.terning.feature.onboarding.signup.navigation.navigateSignUp
 import com.terning.feature.onboarding.signup.navigation.signUpNavGraph
+import com.terning.feature.search.search.navigation.navigateSearch
 import com.terning.feature.search.search.navigation.searchNavGraph
 import com.terning.feature.search.searchprocess.navigation.navigateSearchProcess
 import com.terning.feature.search.searchprocess.navigation.searchProcessNavGraph
@@ -62,6 +63,7 @@ import kotlinx.coroutines.launch
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 @Composable
 fun MainScreen(
+    host: String?,
     redirect: String?,
     navigator: MainNavigator = rememberMainNavigator(),
 ) {
@@ -140,7 +142,7 @@ fun MainScreen(
                     ExitTransition.None
                 },
                 navController = navigator.navController,
-                startDestination = navigator.getStartDestination(redirect)
+                startDestination = navigator.getStartDestination(redirect = redirect, host = host)
             ) {
                 splashNavGraph(
                     navigateHome = {
@@ -159,6 +161,22 @@ fun MainScreen(
                             ).build()
                         )
                     },
+                    navigateCalendar = {
+                        navigator.navController.navigateCalendar(
+                            navOptions = NavOptions.Builder().setPopUpTo(
+                                route = Splash(redirect),
+                                inclusive = true
+                            ).build()
+                        )
+                    },
+                    navigateSearch = {
+                        navigator.navController.navigateSearch(
+                            navOptions = NavOptions.Builder().setPopUpTo(
+                                route = Splash(redirect),
+                                inclusive = true
+                            ).build()
+                        )
+                    }
                 )
                 homeNavGraph(
                     paddingValues = paddingValues,

--- a/feature/main/src/main/java/com/terning/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/terning/feature/main/MainScreen.kt
@@ -70,11 +70,8 @@ fun MainScreen(
     val context = LocalContext.current
     var backPressedState by remember { mutableStateOf(true) }
     var backPressedTime = 0L
-
     val snackBarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
-
-    val amplitudeTracker = LocalTracker.current
 
     BackHandler(enabled = backPressedState) {
         if (System.currentTimeMillis() - backPressedTime <= 3000) {
@@ -90,6 +87,12 @@ fun MainScreen(
         }
         backPressedTime = System.currentTimeMillis()
     }
+
+    val amplitudeTracker = LocalTracker.current
+    val splashNavOptions = NavOptions.Builder().setPopUpTo(
+        route = Splash(redirect),
+        inclusive = true
+    ).build()
 
     Scaffold(
         snackbarHost = {
@@ -146,36 +149,16 @@ fun MainScreen(
             ) {
                 splashNavGraph(
                     navigateHome = {
-                        navigator.navController.navigateHome(
-                            navOptions = NavOptions.Builder().setPopUpTo(
-                                route = Splash(redirect),
-                                inclusive = true
-                            ).build()
-                        )
+                        navigator.navController.navigateHome(navOptions = splashNavOptions)
                     },
                     navigateSignIn = {
-                        navigator.navController.navigateSignIn(
-                            navOptions = NavOptions.Builder().setPopUpTo(
-                                route = Splash(redirect),
-                                inclusive = true
-                            ).build()
-                        )
+                        navigator.navController.navigateSignIn(navOptions = splashNavOptions)
                     },
                     navigateCalendar = {
-                        navigator.navController.navigateCalendar(
-                            navOptions = NavOptions.Builder().setPopUpTo(
-                                route = Splash(redirect),
-                                inclusive = true
-                            ).build()
-                        )
+                        navigator.navController.navigateCalendar(navOptions = splashNavOptions)
                     },
                     navigateSearch = {
-                        navigator.navController.navigateSearch(
-                            navOptions = NavOptions.Builder().setPopUpTo(
-                                route = Splash(redirect),
-                                inclusive = true
-                            ).build()
-                        )
+                        navigator.navController.navigateSearch(navOptions = splashNavOptions)
                     }
                 )
                 homeNavGraph(

--- a/feature/mypage/src/main/java/com/terning/feature/mypage/mypage/MyPageRoute.kt
+++ b/feature/mypage/src/main/java/com/terning/feature/mypage/mypage/MyPageRoute.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -107,17 +106,13 @@ fun MyPageRoute(
             viewModel.updateAlarmAvailability(isGranted)
         }
 
-    SideEffect {
-        systemUiController.setStatusBarColor(
-            color = Back
-        )
+    LaunchedEffect(Unit) {
+        systemUiController.setStatusBarColor(color = Back)
     }
 
     DisposableEffect(lifecycleOwner) {
         onDispose {
-            systemUiController.setStatusBarColor(
-                color = White
-            )
+            systemUiController.setStatusBarColor(color = White)
         }
     }
 

--- a/feature/mypage/src/main/java/com/terning/feature/mypage/profileedit/ProfileEditRoute.kt
+++ b/feature/mypage/src/main/java/com/terning/feature/mypage/profileedit/ProfileEditRoute.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,10 +53,8 @@ fun ProfileEditRoute(
 
     val systemUiController = rememberSystemUiController()
 
-    SideEffect {
-        systemUiController.setStatusBarColor(
-            color = White
-        )
+    LaunchedEffect(Unit) {
+        systemUiController.setStatusBarColor(color = White)
     }
 
     LaunchedEffect(key1 = true) {

--- a/feature/search/src/main/java/com/terning/feature/search/search/SearchRoute.kt
+++ b/feature/search/src/main/java/com/terning/feature/search/search/SearchRoute.kt
@@ -22,7 +22,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.terning.core.analytics.EventType
 import com.terning.core.analytics.LocalTracker
 import com.terning.core.designsystem.component.image.TerningImage
@@ -56,13 +55,6 @@ fun SearchRoute(
     val scrapState by viewModel.scrapState.collectAsStateWithLifecycle(lifecycleOwner = lifecycleOwner)
 
     val amplitudeTracker = LocalTracker.current
-
-    val systemUiController = rememberSystemUiController()
-
-    LaunchedEffect(Unit) {
-        systemUiController.setStatusBarColor(color = White)
-        systemUiController.setNavigationBarColor(color = White)
-    }
 
     LaunchedEffect(key1 = true) {
         viewModel.getSearchViews()

--- a/feature/search/src/main/java/com/terning/feature/search/search/SearchRoute.kt
+++ b/feature/search/src/main/java/com/terning/feature/search/search/SearchRoute.kt
@@ -22,6 +22,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.terning.core.analytics.EventType
 import com.terning.core.analytics.LocalTracker
 import com.terning.core.designsystem.component.image.TerningImage
@@ -55,6 +56,13 @@ fun SearchRoute(
     val scrapState by viewModel.scrapState.collectAsStateWithLifecycle(lifecycleOwner = lifecycleOwner)
 
     val amplitudeTracker = LocalTracker.current
+
+    val systemUiController = rememberSystemUiController()
+
+    LaunchedEffect(Unit) {
+        systemUiController.setStatusBarColor(color = White)
+        systemUiController.setNavigationBarColor(color = White)
+    }
 
     LaunchedEffect(key1 = true) {
         viewModel.getSearchViews()

--- a/feature/search/src/main/java/com/terning/feature/search/search/navigation/SearchNavigation.kt
+++ b/feature/search/src/main/java/com/terning/feature/search/search/navigation/SearchNavigation.kt
@@ -6,11 +6,10 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
+import com.terning.core.designsystem.util.DeeplinkDefaults
 import com.terning.core.navigation.MainTabRoute
 import com.terning.feature.search.search.SearchRoute
 import kotlinx.serialization.Serializable
-
-private const val SEARCH_PATH: String = "terning://search"
 
 fun NavController.navigateSearch(navOptions: NavOptions? = null) {
     navigate(
@@ -24,13 +23,13 @@ fun NavGraphBuilder.searchNavGraph(
     navigateSearchProcess: () -> Unit,
     navigateIntern: (Long) -> Unit,
 ) {
-    composable<Search> (
+    composable<Search>(
         deepLinks = listOf(
             navDeepLink<Search>(
-                basePath = SEARCH_PATH
+                basePath = DeeplinkDefaults.build("search")
             )
         )
-    ){
+    ) {
         SearchRoute(
             paddingValues = paddingValues,
             navigateToSearchProcess = navigateSearchProcess,

--- a/feature/search/src/main/java/com/terning/feature/search/search/navigation/SearchNavigation.kt
+++ b/feature/search/src/main/java/com/terning/feature/search/search/navigation/SearchNavigation.kt
@@ -5,9 +5,12 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navDeepLink
 import com.terning.core.navigation.MainTabRoute
 import com.terning.feature.search.search.SearchRoute
 import kotlinx.serialization.Serializable
+
+private const val SEARCH_PATH: String = "terning://search"
 
 fun NavController.navigateSearch(navOptions: NavOptions? = null) {
     navigate(
@@ -21,7 +24,13 @@ fun NavGraphBuilder.searchNavGraph(
     navigateSearchProcess: () -> Unit,
     navigateIntern: (Long) -> Unit,
 ) {
-    composable<Search> {
+    composable<Search> (
+        deepLinks = listOf(
+            navDeepLink<Search>(
+                basePath = SEARCH_PATH
+            )
+        )
+    ){
         SearchRoute(
             paddingValues = paddingValues,
             navigateToSearchProcess = navigateSearchProcess,

--- a/feature/splash/src/main/java/com/terning/feature/splash/SplashRoute.kt
+++ b/feature/splash/src/main/java/com/terning/feature/splash/SplashRoute.kt
@@ -27,6 +27,7 @@ import com.terning.core.designsystem.extension.getVersionName
 import com.terning.core.designsystem.extension.launchPlayStore
 import com.terning.core.designsystem.theme.TerningMain
 import com.terning.core.designsystem.theme.TerningPointTheme
+import com.terning.core.designsystem.type.NotificationRedirect
 import com.terning.domain.update.entity.UpdateState
 import com.terning.feature.splash.component.TerningMajorUpdateDialog
 import com.terning.feature.splash.component.TerningPatchUpdateDialog
@@ -76,15 +77,15 @@ internal fun SplashRoute(
                 when (sideEffect) {
                     is SplashSideEffect.HasAccessToken -> {
                         if (sideEffect.hasAccessToken) {
-                            if (redirect?.isBlank() == false) {
-                                when (redirect) {
-                                    "calendar" -> navigateToCalendar()
-                                    "home" -> navigateToHome()
-                                    "search" -> navigateToSearch()
-                                    else -> {}
-                                }
-                            } else {
+                            if (redirect.isNullOrBlank()) {
                                 navigateToHome()
+                            } else {
+                                when (NotificationRedirect.from(redirect)) {
+                                    NotificationRedirect.CALENDAR -> navigateToCalendar()
+                                    NotificationRedirect.HOME -> navigateToHome()
+                                    NotificationRedirect.SEARCH -> navigateToSearch()
+                                    else -> navigateToHome()
+                                }
                             }
                         } else {
                             navigateToSignIn()

--- a/feature/splash/src/main/java/com/terning/feature/splash/SplashRoute.kt
+++ b/feature/splash/src/main/java/com/terning/feature/splash/SplashRoute.kt
@@ -27,6 +27,7 @@ import com.terning.core.designsystem.extension.getVersionName
 import com.terning.core.designsystem.extension.launchPlayStore
 import com.terning.core.designsystem.theme.TerningMain
 import com.terning.core.designsystem.theme.TerningPointTheme
+import com.terning.core.designsystem.theme.White
 import com.terning.core.designsystem.type.NotificationRedirect
 import com.terning.domain.update.entity.UpdateState
 import com.terning.feature.splash.component.TerningMajorUpdateDialog
@@ -51,6 +52,13 @@ internal fun SplashRoute(
     LaunchedEffect(Unit) {
         systemUiController.setStatusBarColor(color = TerningMain)
         systemUiController.setNavigationBarColor(color = TerningMain)
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        onDispose {
+            systemUiController.setStatusBarColor(color = White)
+            systemUiController.setNavigationBarColor(color = White)
+        }
     }
 
     DisposableEffect(lifecycleOwner) {

--- a/feature/splash/src/main/java/com/terning/feature/splash/SplashRoute.kt
+++ b/feature/splash/src/main/java/com/terning/feature/splash/SplashRoute.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -38,20 +37,19 @@ internal fun SplashRoute(
     redirect: String?,
     navigateToHome: () -> Unit,
     navigateToSignIn: () -> Unit,
+    navigateToCalendar: () -> Unit,
+    navigateToSearch: () -> Unit,
     viewModel: SplashViewModel = hiltViewModel(),
 ) {
-    val systemUiController = rememberSystemUiController()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
     val updateState by viewModel.updateState.collectAsStateWithLifecycle()
 
-    SideEffect {
-        systemUiController.setStatusBarColor(
-            color = TerningMain
-        )
-        systemUiController.setNavigationBarColor(
-            color = TerningMain
-        )
+    val systemUiController = rememberSystemUiController()
+
+    LaunchedEffect(Unit) {
+        systemUiController.setStatusBarColor(color = TerningMain)
+        systemUiController.setNavigationBarColor(color = TerningMain)
     }
 
     DisposableEffect(lifecycleOwner) {
@@ -77,8 +75,20 @@ internal fun SplashRoute(
             .collect { sideEffect ->
                 when (sideEffect) {
                     is SplashSideEffect.HasAccessToken -> {
-                        if (sideEffect.hasAccessToken) navigateToHome()
-                        else navigateToSignIn()
+                        if (sideEffect.hasAccessToken) {
+                            if (redirect?.isBlank() == false) {
+                                when (redirect) {
+                                    "calendar" -> navigateToCalendar()
+                                    "home" -> navigateToHome()
+                                    "search" -> navigateToSearch()
+                                    else -> {}
+                                }
+                            } else {
+                                navigateToHome()
+                            }
+                        } else {
+                            navigateToSignIn()
+                        }
                     }
                 }
             }

--- a/feature/splash/src/main/java/com/terning/feature/splash/navigation/SplashNavigation.kt
+++ b/feature/splash/src/main/java/com/terning/feature/splash/navigation/SplashNavigation.kt
@@ -14,6 +14,8 @@ private const val SPLASH_PATH: String = "terning://splash"
 fun NavGraphBuilder.splashNavGraph(
     navigateHome: () -> Unit,
     navigateSignIn: () -> Unit,
+    navigateSearch: () -> Unit,
+    navigateCalendar: () -> Unit
 ) {
     composable<Splash>(
         deepLinks = listOf(
@@ -27,6 +29,8 @@ fun NavGraphBuilder.splashNavGraph(
             redirect = args.redirect,
             navigateToHome = navigateHome,
             navigateToSignIn = navigateSignIn,
+            navigateToSearch = navigateSearch,
+            navigateToCalendar = navigateCalendar
         )
     }
 }

--- a/feature/splash/src/main/java/com/terning/feature/splash/navigation/SplashNavigation.kt
+++ b/feature/splash/src/main/java/com/terning/feature/splash/navigation/SplashNavigation.kt
@@ -4,12 +4,11 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
 import androidx.navigation.toRoute
+import com.terning.core.designsystem.util.DeeplinkDefaults
 import com.terning.core.navigation.Route
 import com.terning.feature.splash.SplashRoute
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-
-private const val SPLASH_PATH: String = "terning://splash"
 
 fun NavGraphBuilder.splashNavGraph(
     navigateHome: () -> Unit,
@@ -20,7 +19,7 @@ fun NavGraphBuilder.splashNavGraph(
     composable<Splash>(
         deepLinks = listOf(
             navDeepLink<Splash>(
-                basePath = SPLASH_PATH
+                basePath = DeeplinkDefaults.build("splash")
             )
         )
     ) {


### PR DESCRIPTION
- closed #382

## *⛳️ Work Description*
- [x] Payload 형식 수정 
- [x] 푸시알림에 LargeIcon 추가
- [x] 알림 유형별 분기처리
- [x] 포그라운드 상태일 때 분기처리

## *📸 Screenshot*
| LargeIcon 적용 사진 | 
|:------:|
| <image src="https://github.com/user-attachments/assets/bcbbb15a-1dc2-4a49-933e-6e3e2b48e709" width = 500/>| 

| 처음 알림 클릭 시 <br> `(탐색으로 가는 알림)` | 포그라운드 상태에서 알림 클릭 시 <br> `(홈으로 가는 알림)` | 
|:------:|:-------:|
| <video src="https://github.com/user-attachments/assets/51571290-4cb2-4d4f-aae4-bf935e3d003b"></video> | <video src="https://github.com/user-attachments/assets/60435f28-169c-4557-a862-bb234bfe09b3"></video>  | 


## *📢 To Reviewers*
- 드디어 길고 길었던 푸시알림 구현이 끝났습니다!🥹
- 알림을 클릭했을 때 무조건 스플래쉬를 거치는 것은 맞지만, 앱이 활성화 되어있는 상태(포그라운드)일 때는 바로 그 화면으로 이동하도록 했어요!
- 이를 구현하면서 앱의 진입점(`startDestination`)을 매번 바꾸는 방향으로 수정했습니다! (아린언니 보고 참고해주세요!)
- 고려하지 않게 된 두 가지 사항에 대해서도 이유를 작성해보겠습니당
    1. `업데이트 확인하기(포그라운드)` : 알림 자체를 처음 눌렀을 때는 스플래쉬를 거치기 때문에, 굳이 사용자가 앱을 쓰고 있을 때 업데이트가 일어나는 경우는 고려할 필요가 없다고 판단.
    2. `토큰 유무 확인하기` :  알림을 받기 위해서는 alarmAvailable을 설정해줘야하는데, 로그인이 안 된 상태는 무조건 alarmAvailable이 false임. 그래서 알림을 받을 케이스가 없음
