### PR TITLE
[ADD/#384] 4차 스프린트 / 엠플리튜드 이벤트 추가

### DIFF
--- a/core/analytics/src/main/java/com/terning/core/analytics/EventType.kt
+++ b/core/analytics/src/main/java/com/terning/core/analytics/EventType.kt
@@ -4,5 +4,6 @@ enum class EventType(val prefix: String) {
     SIGNUP("signup"),
     SCREEN("screen"),
     CLICK("click"),
-    SCROLL("scroll")
+    SCROLL("scroll"),
+    PUSH_NOTIFICATION("push_notification")
 }

--- a/core/firebase/build.gradle.kts
+++ b/core/firebase/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     //core
     implementation(projects.core.navigator)
     implementation(projects.core.designsystem)
+    implementation(projects.core.analytics)
 
     // domain
     implementation(projects.domain.user)

--- a/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
+++ b/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
@@ -37,7 +37,7 @@ class TerningMessagingService : FirebaseMessagingService() {
     lateinit var navigatorProvider: NavigatorProvider
 
     @Inject
-    lateinit var tracker: AmplitudeTracker
+    lateinit var amplitudeTracker: AmplitudeTracker
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
@@ -48,23 +48,27 @@ class TerningMessagingService : FirebaseMessagingService() {
     override fun handleIntent(intent: Intent?) {
         super.handleIntent(intent)
 
-        extractInformation(
-            title = intent?.getStringExtra(TITLE),
-            body = intent?.getStringExtra(BODY),
-            type = intent?.getStringExtra(TYPE),
-            imageUrl = intent?.getStringExtra(IMAGE_URL)
-        )
+        if (!isAppInForeground()) {
+            extractInformation(
+                title = intent?.getStringExtra(TITLE),
+                body = intent?.getStringExtra(BODY),
+                type = intent?.getStringExtra(TYPE),
+                imageUrl = intent?.getStringExtra(IMAGE_URL)
+            )
+        }
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
 
-        extractInformation(
-            title = message.data[TITLE],
-            body = message.data[BODY],
-            type = message.data[TYPE],
-            imageUrl = message.data[IMAGE_URL]
-        )
+        if (isAppInForeground()) {
+            extractInformation(
+                title = message.data[TITLE],
+                body = message.data[BODY],
+                type = message.data[TYPE],
+                imageUrl = message.data[IMAGE_URL]
+            )
+        }
     }
 
     private fun extractInformation(
@@ -75,7 +79,7 @@ class TerningMessagingService : FirebaseMessagingService() {
     ) {
         if (title.isNullOrEmpty() || !userRepository.getAlarmAvailable()) return
 
-        tracker.track(
+        amplitudeTracker.track(
             type = EventType.PUSH_NOTIFICATION,
             name = "received"
         )
@@ -101,6 +105,7 @@ class TerningMessagingService : FirebaseMessagingService() {
             action = Intent.ACTION_VIEW
             data = deeplink.toUri()
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(FROM_NOTIFICATION, true)
         }
         val pendingIntent = PendingIntent.getActivity(
             this@TerningMessagingService,
@@ -169,5 +174,6 @@ class TerningMessagingService : FirebaseMessagingService() {
         private const val BODY: String = "body"
         private const val TYPE: String = "type"
         private const val IMAGE_URL: String = "imageUrl"
+        const val FROM_NOTIFICATION: String = "fromNotification"
     }
 }

--- a/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
+++ b/core/firebase/src/main/java/com/terning/core/firebase/messageservice/TerningMessagingService.kt
@@ -14,6 +14,8 @@ import coil3.ImageLoader
 import coil3.request.ImageRequest
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.terning.core.analytics.AmplitudeTracker
+import com.terning.core.analytics.EventType
 import com.terning.core.designsystem.type.NotificationRedirect
 import com.terning.core.designsystem.util.DeeplinkDefaults
 import com.terning.core.designsystem.util.DeeplinkDefaults.REDIRECT
@@ -33,6 +35,9 @@ class TerningMessagingService : FirebaseMessagingService() {
 
     @Inject
     lateinit var navigatorProvider: NavigatorProvider
+
+    @Inject
+    lateinit var tracker: AmplitudeTracker
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
@@ -69,6 +74,11 @@ class TerningMessagingService : FirebaseMessagingService() {
         imageUrl: String?
     ) {
         if (title.isNullOrEmpty() || !userRepository.getAlarmAvailable()) return
+
+        tracker.track(
+            type = EventType.PUSH_NOTIFICATION,
+            name = "received"
+        )
 
         sendNotification(
             title = title,

--- a/feature/main/src/main/java/com/terning/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/terning/feature/main/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.CompositionLocalProvider
 import com.terning.core.analytics.AmplitudeTracker
+import com.terning.core.analytics.EventType
 import com.terning.core.analytics.LocalTracker
 import com.terning.core.designsystem.theme.TerningPointTheme
 import com.terning.core.designsystem.util.DeeplinkDefaults.REDIRECT
@@ -28,8 +29,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             val navigator: MainNavigator = rememberMainNavigator()
-            val redirect: String? = intent.data?.getQueryParameter(REDIRECT)
-            val host: String? = intent.data?.host
+            val (host, redirect) = handleDeeplink(intent)
 
             TerningPointTheme {
                 CompositionLocalProvider(LocalTracker provides tracker) {
@@ -41,6 +41,21 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    private fun handleDeeplink(intent: Intent?): Pair<String?, String?> {
+        val uri = intent?.data
+        val host = uri?.host
+        val redirect = uri?.getQueryParameter(REDIRECT)
+
+        if (uri != null) {
+            tracker.track(
+                type = EventType.PUSH_NOTIFICATION,
+                name = "opened"
+            )
+        }
+
+        return host to redirect
     }
 
     companion object {

--- a/feature/main/src/main/java/com/terning/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/terning/feature/main/MainActivity.kt
@@ -14,6 +14,7 @@ import com.terning.core.analytics.EventType
 import com.terning.core.analytics.LocalTracker
 import com.terning.core.designsystem.theme.TerningPointTheme
 import com.terning.core.designsystem.util.DeeplinkDefaults.REDIRECT
+import com.terning.core.firebase.messageservice.TerningMessagingService.Companion.FROM_NOTIFICATION
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -45,20 +46,30 @@ class MainActivity : ComponentActivity() {
 
     private fun handleDeeplink(intent: Intent?): Pair<String?, String?> {
         val uri = intent?.data
-        val host = uri?.host
-        val redirect = uri?.getQueryParameter(REDIRECT)
+        val uriString = uri?.toString()
 
-        if (uri != null) {
+        if (uriString.isNullOrEmpty()) return null to null
+
+        val host = uri.host
+        val redirect = uri.getQueryParameter(REDIRECT)
+
+        if (!intent.getBooleanExtra(ALREADY_TRACKED, false)
+            && intent.getBooleanExtra(FROM_NOTIFICATION, false)
+        ) {
             tracker.track(
                 type = EventType.PUSH_NOTIFICATION,
                 name = "opened"
             )
         }
 
+        intent.putExtra(ALREADY_TRACKED, true)
+
         return host to redirect
     }
 
     companion object {
+        private const val ALREADY_TRACKED: String = "alreadyTracked"
+
         fun getIntent(
             context: Context,
         ) = Intent(context, MainActivity::class.java)


### PR DESCRIPTION
- closed #384

## *⛳️ Work Description*
- [x] 사용자가 푸시 알림을 받았을 때 이벤트를 로깅
- [x] 푸시 알림을 클릭해서 앱이 열리면, 이벤트를 로깅

## *📸 Screenshot*

<img width="320" alt="스크린샷 2025-04-29 오후 2 46 51" src="https://github.com/user-attachments/assets/5c59e514-390d-4729-84a5-02ff06739643" />


## *📢 To Reviewers*
- 알림으로 연 딥링크라는 것을 식별하기 위해 `FROM_NOTIFICATION`을 추가해줬습니다! 카카오톡으로 딥링크 열면 이벤트 안 심어질 거에요!
- 포그라운드 상태에서 알림을 클릭하면 이벤트가 두 번 축적되는 문제가 있어서 `ALREADY_TRACKED`로 구분해줬어요..!
