### PR TITLE
[FEAT/#390] 일회성 FCM 토큰 / 서버통신 구현

### DIFF
--- a/data/home/src/main/java/com/terning/data/home/datasource/HomeDataSource.kt
+++ b/data/home/src/main/java/com/terning/data/home/datasource/HomeDataSource.kt
@@ -3,6 +3,7 @@ package com.terning.data.home.datasource
 import com.terning.core.network.BaseResponse
 import com.terning.core.network.NonDataBaseResponse
 import com.terning.data.home.dto.request.ChangeFilterRequestDto
+import com.terning.data.home.dto.request.FcmTokenRequestDto
 import com.terning.data.home.dto.response.HomeFilteringInfoResponseDto
 import com.terning.data.home.dto.response.HomeRecommendInternResponseDto
 import com.terning.data.home.dto.response.HomeUpcomingInternResponseDto
@@ -18,4 +19,6 @@ interface HomeDataSource {
     suspend fun getFilteringInfo(): BaseResponse<HomeFilteringInfoResponseDto>
 
     suspend fun putFilteringInfo(changeFilterRequestDto: ChangeFilterRequestDto): NonDataBaseResponse
+
+    suspend fun sendFcmToken(fcmTokenRequestDto: FcmTokenRequestDto): NonDataBaseResponse
 }

--- a/data/home/src/main/java/com/terning/data/home/datasourceimpl/HomeDataSourceImpl.kt
+++ b/data/home/src/main/java/com/terning/data/home/datasourceimpl/HomeDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.terning.core.network.BaseResponse
 import com.terning.core.network.NonDataBaseResponse
 import com.terning.data.home.datasource.HomeDataSource
 import com.terning.data.home.dto.request.ChangeFilterRequestDto
+import com.terning.data.home.dto.request.FcmTokenRequestDto
 import com.terning.data.home.dto.response.HomeFilteringInfoResponseDto
 import com.terning.data.home.dto.response.HomeRecommendInternResponseDto
 import com.terning.data.home.dto.response.HomeUpcomingInternResponseDto
@@ -30,4 +31,7 @@ class HomeDataSourceImpl @Inject constructor(
 
     override suspend fun putFilteringInfo(changeFilterRequestDto: ChangeFilterRequestDto): NonDataBaseResponse =
         homeService.putFilteringInfo(changeFilterRequestDto)
+
+    override suspend fun sendFcmToken(fcmTokenRequestDto: FcmTokenRequestDto): NonDataBaseResponse =
+        homeService.sendFcmToken(fcmTokenRequestDto)
 }

--- a/data/home/src/main/java/com/terning/data/home/dto/request/FcmTokenRequestDto.kt
+++ b/data/home/src/main/java/com/terning/data/home/dto/request/FcmTokenRequestDto.kt
@@ -1,0 +1,10 @@
+package com.terning.data.home.dto.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FcmTokenRequestDto(
+    @SerialName("fcmToken")
+    val fcmToken: String
+)

--- a/data/home/src/main/java/com/terning/data/home/mapper/FcmTokenMapper.kt
+++ b/data/home/src/main/java/com/terning/data/home/mapper/FcmTokenMapper.kt
@@ -1,0 +1,9 @@
+package com.terning.data.home.mapper
+
+import com.terning.data.home.dto.request.FcmTokenRequestDto
+import com.terning.domain.home.entity.FcmToken
+
+fun FcmToken.toRequestDto(): FcmTokenRequestDto =
+    FcmTokenRequestDto(
+        fcmToken = fcmToken
+    )

--- a/data/home/src/main/java/com/terning/data/home/repositoryimpl/HomeRepositoryImpl.kt
+++ b/data/home/src/main/java/com/terning/data/home/repositoryimpl/HomeRepositoryImpl.kt
@@ -9,8 +9,10 @@ import com.terning.data.home.dto.request.toChangeFilterRequestDto
 import com.terning.data.home.mapper.toHomeFilteringInfo
 import com.terning.data.home.mapper.toHomeRecommendedIntern
 import com.terning.data.home.mapper.toHomeUpcomingInternList
+import com.terning.data.home.mapper.toRequestDto
 import com.terning.data.home.pagingsource.HomePagingSource
 import com.terning.domain.home.entity.ChangeFilteringRequestModel
+import com.terning.domain.home.entity.FcmToken
 import com.terning.domain.home.entity.HomeFilteringInfo
 import com.terning.domain.home.entity.HomeRecommendedIntern
 import com.terning.domain.home.entity.HomeUpcomingIntern
@@ -51,5 +53,10 @@ class HomeRepositoryImpl @Inject constructor(
             homeDataSource.putFilteringInfo(
                 putFilteringRequest.toChangeFilterRequestDto()
             )
+        }
+
+    override suspend fun sendFcmToken(fcmTokenRequest: FcmToken): Result<Unit> =
+        runCatching {
+            homeDataSource.sendFcmToken(fcmTokenRequest.toRequestDto())
         }
 }

--- a/data/home/src/main/java/com/terning/data/home/service/HomeService.kt
+++ b/data/home/src/main/java/com/terning/data/home/service/HomeService.kt
@@ -3,11 +3,13 @@ package com.terning.data.home.service
 import com.terning.core.network.BaseResponse
 import com.terning.core.network.NonDataBaseResponse
 import com.terning.data.home.dto.request.ChangeFilterRequestDto
+import com.terning.data.home.dto.request.FcmTokenRequestDto
 import com.terning.data.home.dto.response.HomeFilteringInfoResponseDto
 import com.terning.data.home.dto.response.HomeRecommendInternResponseDto
 import com.terning.data.home.dto.response.HomeUpcomingInternResponseDto
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Query
 
@@ -28,4 +30,7 @@ interface HomeService {
     suspend fun putFilteringInfo(
         @Body body: ChangeFilterRequestDto,
     ): NonDataBaseResponse
+
+    @POST("api/v1/auth/sync-user")
+    suspend fun sendFcmToken(@Body body: FcmTokenRequestDto): NonDataBaseResponse
 }

--- a/domain/home/src/main/java/com/terning/domain/home/entity/FcmToken.kt
+++ b/domain/home/src/main/java/com/terning/domain/home/entity/FcmToken.kt
@@ -1,0 +1,5 @@
+package com.terning.domain.home.entity
+
+data class FcmToken(
+    val fcmToken: String
+)

--- a/domain/home/src/main/java/com/terning/domain/home/repository/HomeRepository.kt
+++ b/domain/home/src/main/java/com/terning/domain/home/repository/HomeRepository.kt
@@ -2,6 +2,7 @@ package com.terning.domain.home.repository
 
 import androidx.paging.PagingData
 import com.terning.domain.home.entity.ChangeFilteringRequestModel
+import com.terning.domain.home.entity.FcmToken
 import com.terning.domain.home.entity.HomeFilteringInfo
 import com.terning.domain.home.entity.HomeRecommendedIntern
 import com.terning.domain.home.entity.HomeUpcomingIntern
@@ -19,4 +20,6 @@ interface HomeRepository {
     suspend fun putFilteringInfo(
         putFilteringRequest: ChangeFilteringRequestModel,
     ): Result<Unit>
+
+    suspend fun sendFcmToken(fcmTokenRequest: FcmToken): Result<Unit>
 }

--- a/feature/home/src/main/java/com/terning/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/HomeRoute.kt
@@ -95,6 +95,8 @@ fun HomeRoute(
         if (!permissionState.status.isGranted && !viewModel.getPermissionRequested()) {
             permissionState.launchPermissionRequest()
 
+            viewModel.fetchAndSaveFcmToken()
+
             snapshotFlow { permissionState.status }
                 .map { it is PermissionStatus.Granted }
                 .distinctUntilChanged()

--- a/feature/home/src/main/java/com/terning/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/terning/feature/home/HomeViewModel.kt
@@ -8,6 +8,7 @@ import androidx.paging.map
 import com.terning.core.designsystem.state.UiState
 import com.terning.core.designsystem.type.SortBy
 import com.terning.domain.home.entity.ChangeFilteringRequestModel
+import com.terning.domain.home.entity.FcmToken
 import com.terning.domain.home.entity.HomeRecommendIntern
 import com.terning.domain.home.entity.HomeRecommendedIntern
 import com.terning.domain.home.repository.HomeRepository
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 import com.terning.core.designsystem.R as DesignSystemR
 
@@ -224,6 +226,22 @@ class HomeViewModel @Inject constructor(
         userRepository.setPermissionRequested(requested)
     }
 
-    fun getPermissionRequested() : Boolean = userRepository.getPermissionRequested()
+    fun getPermissionRequested(): Boolean = userRepository.getPermissionRequested()
 
+    fun fetchAndSaveFcmToken() {
+        viewModelScope.launch {
+            userRepository.fetchAndSetFcmToken()
+                .onSuccess {
+                    sendFcmToken()
+                }.onFailure(Timber::e)
+        }
+    }
+
+    private fun sendFcmToken() {
+        viewModelScope.launch {
+            homeRepository.sendFcmToken(
+                FcmToken(userRepository.getFcmToken())
+            ).onFailure(Timber::e)
+        }
+    }
 }


### PR DESCRIPTION
- closed #390

## *⛳️ Work Description*
- [x] 일회성 FCM 토큰 알림 다이얼로그에 구현

## *📸 Screenshot*
- 해당 API를 연결하는 다이얼로그입니다!
<img width="295" alt="KakaoTalk_Photo_2025-05-11-23-24-56" src="https://github.com/user-attachments/assets/b5b0edcc-22f2-43d2-b6f1-04815fc896fd" />


## *📢 To Reviewers*
- 현재 기존 유저는 FCM 토큰을 발급할 수 있는 로직이 없어서 알림 다이얼로그를 띄울 때 FCM 토큰을 서버에 보내는 로직을 추가해 줬습니다.
- 서버 팀원에 문의해 보았을 때 이 API는 "`해당 유저가 이미 존재하고 토큰값이 일치하지 않다면 변경해주고, 존재하지않으면 새롭게 반영해주는 로직`" 이라고 합니다.
- 이 때문에 알림 다이얼로그가 다시 떠서 해당 API가 재호출되더라도 성능상 큰 차이가 없어 문제 없을 거라는 답변을 받았습니다..!
- 추가로.. 아키텍처적인 고민도 있었는데 home 뷰라서 `:domain:home` 모듈에 작성하긴 했는데 회원을 관리하는 도메인에 넣을까 하다가 이는 리팩토링 할 때 한 번에 하는 게 좋을 것 같아 일단은 이렇게 구현했습니당..!