### PR TITLE
[FEAT/#400] 429 상태 코드 대응 

### DIFF
--- a/core/network/src/main/java/com/terning/core/network/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/terning/core/network/AuthInterceptor.kt
@@ -61,8 +61,14 @@ class AuthInterceptor @Inject constructor(
                 terningDataStore.clearInfo()
 
                 Handler(Looper.getMainLooper()).post {
-                    Toast.makeText(context, TOKEN_EXPIRED_ERROR, Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, MESSAGE_TOKEN_EXPIRED, Toast.LENGTH_LONG).show()
                     ProcessPhoenix.triggerRebirth(context)
+                }
+            }
+
+            CODE_MANY_REQUESTS -> {
+                Handler(Looper.getMainLooper()).post {
+                    Toast.makeText(context, MESSAGE_TOO_MANY_REQUESTS, Toast.LENGTH_LONG).show()
                 }
             }
         }
@@ -74,7 +80,9 @@ class AuthInterceptor @Inject constructor(
 
     companion object {
         private const val CODE_TOKEN_EXPIRED = 401
-        private const val TOKEN_EXPIRED_ERROR = "토큰이 만료되었어요\n다시 로그인 해주세요"
+        private const val CODE_MANY_REQUESTS = 429
+        private const val MESSAGE_TOKEN_EXPIRED = "토큰이 만료되었어요\n다시 로그인 해주세요"
+        private const val MESSAGE_TOO_MANY_REQUESTS = "요청 횟수가 너무 많아요\n잠시 후 다시 시도해 주세요"
         private const val BEARER = "Bearer"
         private const val AUTHORIZATION = "Authorization"
     }

--- a/core/network/src/main/java/com/terning/core/network/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/terning/core/network/AuthInterceptor.kt
@@ -58,18 +58,11 @@ class AuthInterceptor @Inject constructor(
                     Timber.d(t.message)
                 }
 
-                terningDataStore.clearInfo()
-
-                Handler(Looper.getMainLooper()).post {
-                    Toast.makeText(context, MESSAGE_TOKEN_EXPIRED, Toast.LENGTH_LONG).show()
-                    ProcessPhoenix.triggerRebirth(context)
-                }
+                restartApp(MESSAGE_TOKEN_EXPIRED)
             }
 
             CODE_MANY_REQUESTS -> {
-                Handler(Looper.getMainLooper()).post {
-                    Toast.makeText(context, MESSAGE_TOO_MANY_REQUESTS, Toast.LENGTH_LONG).show()
-                }
+                restartApp(MESSAGE_TOO_MANY_REQUESTS)
             }
         }
         return response
@@ -77,6 +70,15 @@ class AuthInterceptor @Inject constructor(
 
     private fun Request.Builder.newAuthBuilder() =
         this.addHeader(AUTHORIZATION, "$BEARER ${terningDataStore.accessToken}")
+
+    private fun restartApp(message: String) {
+        terningDataStore.clearInfo()
+
+        Handler(Looper.getMainLooper()).post {
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+            ProcessPhoenix.triggerRebirth(context)
+        }
+    }
 
     companion object {
         private const val CODE_TOKEN_EXPIRED = 401

--- a/core/network/src/main/java/com/terning/core/network/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/terning/core/network/AuthInterceptor.kt
@@ -84,7 +84,7 @@ class AuthInterceptor @Inject constructor(
         private const val CODE_TOKEN_EXPIRED = 401
         private const val CODE_MANY_REQUESTS = 429
         private const val MESSAGE_TOKEN_EXPIRED = "토큰이 만료되었어요\n다시 로그인 해주세요"
-        private const val MESSAGE_TOO_MANY_REQUESTS = "요청 횟수가 너무 많아요\n잠시 후 다시 시도해 주세요"
+        private const val MESSAGE_TOO_MANY_REQUESTS = "요청 횟수가 너무 많아요\n로그인 후 다시 시도해 주세요"
         private const val BEARER = "Bearer"
         private const val AUTHORIZATION = "Authorization"
     }


### PR DESCRIPTION
- closed #400

## *⛳️ Work Description*
- [x] 429 상태 코드 대응

제가 이번에 429 상태 코드 대응을 하면서 인터셉터에서 토스트를 띄운 후, 로그인을 다시 유도하는 로직을 작성했는데요!
이렇게 생각하게 된 이유는 다음과 같습니다.
```
1. 유효하지 않은 토큰을 무한 요청하는 경우는 언제인가? 
- 안드가 개발 초기에 자동로그인으로 들어간 홈화면에서 서버통신을 했을 때
- 스플래쉬 -> 홈 -> 스플래쉬 -> 홈
 이라는 무한 굴레에 빠지게 된 경우 밖에 없었던 것 같음 (토큰이 안정적이지 않았기 때문으로 추측됨) 

2. 그럼 서버에서 요청해줬던 로그인 버튼 비활성화 대응은 마땅한가?
- 로그인 화면은 토큰이 없어야 진입이 가능하기 때문에 로그인 단에서 무한굴레에 빠지지 않을 것 같다는 생각
- 따라서 로그인 버튼을 비활성화 하는 것으로는 무한 요청을 막는데 영향을 주지 않겠다는 판단이 들었음

3. 그럼 과도한 서버통신 요청을  하는 경우는 언제인가?
- 진짜 알 수 없는 비정상적인 경우
- 혹은 사용자가 1분에 공고 10개를 스크랩한다던지와 같은 경우
- 이를 우려해  사용자가 쉽게 서버통신을 요청할 수 있는 알림 토글의 경우 이미 안드는 사전에 막아놓음
- 그래서 일단 과도한 서버통신을 요청하는 경우는 비정상적인 경우로 간주하고 토스트로 사용자에게 노티후 로그인부터 다시 하게 유도하는 방법 고안
```
## *📢 To Reviewers*
- 영광의 400번대 이슈입니다🍀🍀
- 추가로 `리팩토링 작업` 마일스톤 생성했어요! 
